### PR TITLE
Import `config` object before referencing it

### DIFF
--- a/webapp/server/config.js
+++ b/webapp/server/config.js
@@ -96,7 +96,7 @@ const config = {
         // TODO: Document this.
         WORKFLOW_TYPE: process.env.CROMWELL_WORKFLOW_TYPE || "WDL",
         // TODO: Document this.
-        WORKFLOW_TYPE_VERSION: process.env.CROMWELL_WORKFLOW_VERSION || "draft-2",
+        WORKFLOW_TYPE_VERSION: process.env.CROMWELL_WORKFLOW_TYPE_VERSION || "draft-2",
     },
     CRON: {
         // Port number on which the cron web server will listen for HTTP requests.

--- a/webapp/server/routes/common.js
+++ b/webapp/server/routes/common.js
@@ -24,6 +24,7 @@ const encodePassword = function (password) {
         bcrypt.genSalt(10, (err, salt) => {
             bcrypt.hash(password, salt, (err, hash) => {
                 if (err) {
+                    // FIXME: Where is `logger` defined?
                     logger.error("Failed to encode password: " + err);
                     return reject(err);
                 }
@@ -40,10 +41,12 @@ const signToken = function (payload) {
             payload,
             config.AUTH.JWT_SECRET,
             {
+                // TODO: Consider defining this in `config.js`.
                 expiresIn: 31556926 // 1 year in seconds
             },
             (err, token) => {
                 if (err) {
+                    // FIXME: Where is `logger` defined?
                     logger.error("Failed to generate a jwt token: " + err);
                     return reject(err);
                 }

--- a/webapp/server/routes/common.js
+++ b/webapp/server/routes/common.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require("path");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
+const config= require("../config");
 
 const { getResult, getRunStats, getConf } = require("../util/pipeline");
 

--- a/webapp/server/routes/common.js
+++ b/webapp/server/routes/common.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require("path");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
-const config= require("../config");
+const config = require("../config");
 
 const { getResult, getRunStats, getConf } = require("../util/pipeline");
 


### PR DESCRIPTION
### Summary of changes

In PR #17, I accidentally left out a `require` statement in `webapp/server/routes/common.js`. In this branch, I have added that `require` statement.

Also, in PR #17, I accidentally left out part of an environment variable's name in `webapp/server/config.js`. In this branch, I have added it.

Finally, I added some "FIXME" comments as I noticed some references to a `logger` object that I didn't see defined anywhere in the file.