### PR TITLE
Fix documentation link and simplify URL construction

### DIFF
--- a/webapp/client/src/config.js
+++ b/webapp/client/src/config.js
@@ -64,13 +64,17 @@ const makeBoolean = (val = "") => {
  * - https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol
  * - https://developer.mozilla.org/en-US/docs/Web/API/Location/host
  *
- * @param pathWithLeadingSlash {string} The path portion of the URI, including the leading forward slash
+ * @param path {string} The path portion of the URI
  * @return {string} The resulting local URI
  */
-const makeLocalUri = (pathWithLeadingSlash = "/") => {
+const makeLocalUri = (path = "") => {
     const protocol = window.location.protocol; // e.g. "http:" or "https:"
     const host = window.location.host; // e.g. "www.example.com" or "www.example.com:1234"
-    return `${protocol}//${host}${pathWithLeadingSlash}`;
+
+    // If the path is non-empty and lacks a leading slash, prepend one.
+    const sanitizedPath = path.length > 0 && path.charAt(0) !== "/" ? `/${path}` : path;
+
+    return `${protocol}//${host}${sanitizedPath}`;
 };
 
 /**
@@ -99,7 +103,7 @@ const config = {
     }, API: {
         // Base URI at which visitors can access the application.
         // Note: This is written under the assumption that the client and API server share a domain.
-        BASE_URI: process.env.REACT_APP_API_URL || makeLocalUri("/"),
+        BASE_URI: process.env.REACT_APP_API_URL || makeLocalUri(),
     }, ORCID: {
         // Boolean flag indicating whether the client will offer ORCiD-based authentication.
         IS_ENABLED: makeBoolean(process.env.REACT_APP_IS_ORCID_AUTH_ENABLED) || false,

--- a/webapp/client/src/pipelines/Common/TutorialBar.js
+++ b/webapp/client/src/pipelines/Common/TutorialBar.js
@@ -59,7 +59,7 @@ function TutorialBar(props) {
                 <Col xs="2" md="2" lg="2">
                     {props.pdfFrench &&
                         <center>
-                            <IconButton style={{ color: 'white' }} aria-label="pdf" href={process.env.REACT_APP_API_URL + props.pdfFrench} target="_blank">
+                            <IconButton style={{ color: 'white' }} aria-label="pdf" href={config.API.BASE_URI + props.pdfFrench} target="_blank">
                                 <FaFilePdf />
                             </IconButton>
                         </center>


### PR DESCRIPTION
In this branch, I updated a documentation link so it gets its base URL from the same place (i.e. config variable) that all the others do, instead of it bypassing that and reading from `process.env` directly. That will make them all behave the same way.

Then, I updated that config variable so that—when the build environment doesn't have a `REACT_APP_API_URL` environment variable defined in it (which is a valid scenario)—the config variable takes on a default value that is compatible with the way the `TutorialBar` component builds URLs (specifically, the config variable's default value doesn't end with a trailing slash anymore).

Those two changes, together, fix some documentation links that are broken when the React app's build environment lacked a `REACT_APP_API_URL` environment variable. Screenshots of broken links fixed by these changes are below:

1. Double slash bug:
   ![image](https://github.com/microbiomedata/nmdc-edge/assets/134325062/63197f8c-3a94-492c-b30d-c27c47813b28)
2. `undefined` bug:
   ![image](https://github.com/microbiomedata/nmdc-edge/assets/134325062/b9f07f3d-1b52-471b-8c78-faac9de4b9f2)