### PR TITLE
Implement Dockerfile that uses Node v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ You can build a new version of the `webapp` container image by issuing one of th
   containers based upon the image will run, are the **same** (e.g. both are arm64, or both are AMD64); then you can use
   this command to build the image (replace `{some_tag}` with a unique identifier for this version, such as `v1.2.3`):
   ```shell
-  docker build -f webapp-node18.Dockerfile \
+  docker build -f webapp-node20.Dockerfile \
                -t nmdc-edge-web-app:{some_tag} .
   ```
   <details>
     <summary>Example</summary>
 
     ```console
-    $ docker build -f webapp-node18.Dockerfile -t nmdc-edge-web-app:v1.2.3 .
+    $ docker build -f webapp-node20.Dockerfile -t nmdc-edge-web-app:v1.2.3 .
     ```
   </details>
 
@@ -172,14 +172,14 @@ You can build a new version of the `webapp` container image by issuing one of th
   command to build the image (replace `{some_tag}` with a unique identifier for this version, such as `v1.2.3`):
   ```shell
   docker buildx build --platform linux/amd64 \
-                      -f webapp-node18.Dockerfile \
+                      -f webapp-node20.Dockerfile \
                       -t nmdc-edge-web-app:some-tag .
   ```
   <details>
     <summary>Example</summary>
 
     ```console
-    $ docker buildx build --platform linux/amd64 -f webapp-node18.Dockerfile -t nmdc-edge-web-app:v1.2.3 .
+    $ docker buildx build --platform linux/amd64 -f webapp-node20.Dockerfile -t nmdc-edge-web-app:v1.2.3 .
     ```
   </details>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 
   # The NMDC EDGE web app (both client and server).
   webapp:
-    build: { context: ".", dockerfile: "webapp-node18.Dockerfile" }
+    build: { context: ".", dockerfile: "webapp-node20.Dockerfile" }
     # Override the container image's default command (i.e. the `CMD` defined in the Dockerfile), so that
     # PM2 runs in "watch" mode (i.e. so that PM2 restarts the application whenever a file changes).
     # Reference: https://pm2.keymetrics.io/docs/usage/restart-strategies/

--- a/webapp-node16.Dockerfile
+++ b/webapp-node16.Dockerfile
@@ -9,6 +9,7 @@ FROM node:16-alpine
 # Add metadata to the Docker image.
 # Reference: https://docs.docker.com/engine/reference/builder/#label
 LABEL org.opencontainers.image.description="NMDC EDGE Web App (Node v16)"
+LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-edge"
 
 # Install programs upon which the web app or its build process(es) depend.
 #

--- a/webapp-node18.Dockerfile
+++ b/webapp-node18.Dockerfile
@@ -9,6 +9,7 @@ FROM node:18-alpine
 # Add metadata to the Docker image.
 # Reference: https://docs.docker.com/engine/reference/builder/#label
 LABEL org.opencontainers.image.description="NMDC EDGE Web App (Node v18)"
+LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-edge"
 
 # Install programs upon which the web app or its build process(es) depend.
 #

--- a/webapp-node20.Dockerfile
+++ b/webapp-node20.Dockerfile
@@ -9,6 +9,7 @@ FROM node:20-alpine
 # Add metadata to the Docker image.
 # Reference: https://docs.docker.com/engine/reference/builder/#label
 LABEL org.opencontainers.image.description="NMDC EDGE Web App (Node v20)"
+LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-edge"
 
 # Install programs upon which the web app or its build process(es) depend.
 #

--- a/webapp-node20.Dockerfile
+++ b/webapp-node20.Dockerfile
@@ -1,0 +1,83 @@
+###############################################################################
+# This is a Dockerfile you can use to build a container image that runs the   #
+# NMDC EDGE Web App. Its design was influenced by the installation script     #
+# at `installation/install.sh`.                                               #
+###############################################################################
+
+FROM node:20-alpine
+
+# Add metadata to the Docker image.
+# Reference: https://docs.docker.com/engine/reference/builder/#label
+LABEL org.opencontainers.image.description="NMDC EDGE Web App (Node v20)"
+
+# Install programs upon which the web app or its build process(es) depend.
+#
+# Note: `apk` (Alpine Package Keeper) is the Alpine Linux equivalent of `apt`.
+#       Docs: https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper
+#
+RUN apk update && apk add \
+  zip
+
+# Update npm, itself, to the latest version.
+RUN npm install -g npm@latest
+
+# Install the latest version of PM2 globally (https://github.com/Unitech/pm2).
+RUN npm install -g pm2@latest
+
+# Set up both the web app client and the web app server.
+#
+# Note: I am intentionally omitting this Dockerfile from this COPY operation because I don't
+#       want to trigger lots of cache misses while I'm still developing this Dockerfile.
+#
+# Note: By copying so much of the file tree this early in the Docker image build process,
+#       we may be missing out on some Docker image layer caching opportunities.
+#
+RUN mkdir /app
+WORKDIR /app
+COPY ./data          /app/data
+COPY ./installation  /app/installation
+COPY ./webapp        /app/webapp
+COPY ./nmdc-edge.jpg /app/nmdc-edge.jpg
+COPY ./pm2.config.js /app/pm2.config.js
+#
+# Generate empty folders (like `installation/install.sh` does).
+# Note: `mkdir -p` automatically creates any necessary intermediate folders.
+#
+RUN mkdir -p io
+RUN cd io && mkdir -p upload/files upload/tmp log projects public db sra
+#
+# Generate an `imports.zip` file for each group of WDL files (like `installation/install.sh` does).
+#
+RUN cd /app/data/workflow/WDL/metaG         && zip -r imports.zip *.wdl
+RUN cd /app/data/workflow/WDL/metaP         && zip -r imports.zip *.wdl
+RUN cd /app/data/workflow/WDL/metaT         && zip -r imports.zip *.wdl
+RUN cd /app/data/workflow/WDL/organicMatter && zip -r imports.zip *.wdl
+RUN cd /app/data/workflow/WDL/virusPlasmids && zip -r imports.zip *.wdl
+RUN cd /app/data/workflow/WDL/sra           && zip -r imports.zip *.wdl
+#
+# Install the npm packages upon which the web app client depends.
+#
+# Note: The `--legacy-peer-deps` option is here because some of the npm packages upon which the web app depends,
+#       have conflicting dependencies with one another. The `--legacy-peer-deps` option causes npm to be more
+#       lenient about stuff like that. Reference: https://stackoverflow.com/a/66620869
+#
+RUN cd webapp/client && npm ci --legacy-peer-deps
+#
+# Build the web app client (i.e. React app).
+#
+# Note: Prefix the `npm run build` command with `NODE_OPTIONS=--openssl-legacy-provider`
+#       in order to work around https://github.com/microbiomedata/nmdc-edge/issues/15.
+#
+RUN cd webapp/client && NODE_OPTIONS=--openssl-legacy-provider npm run build
+#
+# Build the web app server (e.g. Express app).
+#
+RUN cd webapp/server && npm ci
+
+# Run PM2 in the foreground. PM2 will serve the NMDC EDGE web app.
+#
+# Note: We use `pm2-runtime` (instead of `pm2` directly), as shown in the PM2
+#       documentation about using PM2 inside containers.
+#       Docs: https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/
+#
+CMD ["pm2-runtime", "start", "pm2.config.js"]


### PR DESCRIPTION
In this branch, I introduced a third `Dockerfile`: `webapp-node20.Dockerfile`. That `Dockerfile` can be used to build a container image running Node version 20. I also updated the `docker-compose.yml` file so that local development environments include a container image build from that new `Dockerfile`. Finally, I updated the container image building instructions in `README.md` file so that they refer to this new `Dockerfile` instead of the "Node v18" one.