### PR TITLE
Share `io` directory and validate directory paths on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ Once the development stack is up and running, you can access various pieces of i
 ---
 title: Accessing parts of the development stack
 ---
-graph BT
-    host["Terminal<br>(You are here)"]
-    
+graph LR
     %% Links:
+    host -- "$ cd ./io" --> io
     host -- "$ curl http://localhost:8000" --> server
     host -- "$ curl http://localhost:8001" --> cromwell_server
     host -- "$ docker compose exec webapp sh" --> webapp_shell
     webapp_shell -- "# mongo --host mongo:27017" --> db
+    webapp_shell -- "# cd /app/io" --> io
     host -- "$ mongo --host localhost:27017" --> db
     webapp_shell -- "# wget -q -O- http://cromwell:8000" --> cromwell_server
     
@@ -139,7 +139,12 @@ graph BT
     
     subgraph CromwellContainer["cromwell container"]
         cromwell_server["Cromwell server"]
-    end    
+    end
+    
+    subgraph Host["Host"]
+        host["Terminal<br>(You are here)"]
+        io[("IO directory")]
+    end        
 ```
 
 ## Deployment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       #
       - "./webapp:/app/webapp"
       #
+      # Mount the host's "io" directory within the container, so that the host can "see" files uploaded via the web UI.
+      # The host path is set to `./io` by default, since that is what the `installation/install.sh` script used to do.
+      #
+      - ${IO_BASE_DIR_ON_HOST:-./io}:/app/io
+      #
       # ...but, don't mount the following subdirectories. For these subdirectories, we want the container to be
       # initialized with the subdirectories as they exist in the container image, instead of as they exist on the host.
       # That way (a) the installed npm packages are consistent with the container's architecture (i.e. amd64 vs. arm64);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       - "./webapp:/app/webapp"
       #
       # Mount the host's "io" directory within the container, so that the host can "see" files uploaded via the web UI.
-      # The host path is set to `./io` by default, since that is what the `installation/install.sh` script used to do.
+      # The host path is set to `./io` by default, in an attempt to create a configuration familiar to people used to
+      # using the `installation/install.sh` script.
       #
       - ${IO_BASE_DIR_ON_HOST:-./io}:/app/io
       #

--- a/webapp/server/server.js
+++ b/webapp/server/server.js
@@ -48,7 +48,7 @@ const ensureDirectoryIsUsable = (path) => {
     }
   } catch (error) {
     // Create a directory there to which this process has full access.
-    fs.mkdirSync(path, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(path, {recursive: true, mode: 0o700});
     console.debug("Created directory:", path);
   }
 };
@@ -63,8 +63,7 @@ const ensureDirectoriesAreUsable = () => {
     config.IO.UPLOADED_FILES_DIR,
     config.IO.UPLOADED_FILES_TEMP_DIR,
     config.PROJECTS.BASE_DIR,
-]
-    .forEach((path) => ensureDirectoryIsUsable(path));
+  ].forEach((path) => ensureDirectoryIsUsable(path));
 };
 
 // Ensure directories are usable.

--- a/webapp/server/server.js
+++ b/webapp/server/server.js
@@ -26,6 +26,50 @@ const dbBackup = require("./crons/dbBackup");
 const dbBackupClean = require("./crons/dbBackupClean");
 const config = require("./config");
 
+/**
+ * Ensures there is a usable directory at the specified path.
+ *
+ * References:
+ * - https://nodejs.org/api/fs.html#fsfstatsyncfd-options
+ * - https://nodejs.org/api/fs.html#fsmkdirsyncpath-options
+ * - https://nodejs.org/api/fs.html#fsaccesssyncpath-mode
+ * - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates#octal_numbers
+ */
+const ensureDirectoryIsUsable = (path) => {
+  try {
+    // Check whether this process has full access to that path.
+    if (fs.statSync(path).isDirectory()) {
+      // Note: `fs.accessSync` throws an exception if access fails.
+      fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK | fs.constants.X_OK);
+      console.error("Directory is usable:", path);
+    } else {
+      console.error("Directory is not usable:", path);
+      throw new Error(`Directory is not usable: ${path}`);
+    }
+  } catch (error) {
+    // Create a directory there to which this process has full access.
+    fs.mkdirSync(path, { recursive: true, mode: 0o700 });
+    console.debug("Created directory:", path);
+  }
+};
+
+/**
+ * Ensures directories are usable.
+ */
+const ensureDirectoriesAreUsable = () => {
+  [
+    config.IO.UPLOADED_FILES_DIR,
+    config.IO.PUBLIC_BASE_DIR,
+    config.IO.UPLOADED_FILES_DIR,
+    config.IO.UPLOADED_FILES_TEMP_DIR,
+    config.PROJECTS.BASE_DIR,
+]
+    .forEach((path) => ensureDirectoryIsUsable(path));
+};
+
+// Ensure directories are usable.
+ensureDirectoriesAreUsable();
+
 const app = express();
 app.use(express.json());
 app.use(fileUpload({

--- a/webapp/server/server.js
+++ b/webapp/server/server.js
@@ -37,9 +37,9 @@ const config = require("./config");
  */
 const ensureDirectoryIsUsable = (path) => {
   try {
-    // Check whether this process has full access to that path.
+    // Check whether there is a directory at that path and that this process has full access to it.
+    // Note: `fs.accessSync` throws an exception if access fails.
     if (fs.statSync(path).isDirectory()) {
-      // Note: `fs.accessSync` throws an exception if access fails.
       fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK | fs.constants.X_OK);
       console.error("Directory is usable:", path);
     } else {

--- a/webapp/server/server.js
+++ b/webapp/server/server.js
@@ -58,7 +58,6 @@ const ensureDirectoryIsUsable = (path) => {
  */
 const ensureDirectoriesAreUsable = () => {
   [
-    config.IO.UPLOADED_FILES_DIR,
     config.IO.PUBLIC_BASE_DIR,
     config.IO.UPLOADED_FILES_DIR,
     config.IO.UPLOADED_FILES_TEMP_DIR,


### PR DESCRIPTION
In this branch, I made it so the `io` directory (which was already mounted at `/app/io` within the `webapp` container) is shared between the host and the container.

I also updated the web server to verify that certain directories exists (and are accessible to the web server process) during its boot. If it doesn't exist, the web server will create it. It currently creates it with mode `rwx --- ---` (I don't know the requirements).