### PR TITLE
Implement `docker-compose.yml` for production deployment of web app

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Documentation
+
+This directory contains documentation and files related to managing the NMDC EDGE web application.
+
+## Table of contents
+
+- `./README.md` - (You are here)
+- `./docker-compose.prod.yml` - A `docker-compose.yml` file designed to facilitate deploying the NMDC EDGE web
+  application to a production* environment.
+  > *Note: Since we are still preparing the environment that will eventually host the production instance of NMDC EDGE,
+  > this file currently contains references to a development hostname instead of the production hostname.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,3 @@ This directory contains documentation and files related to managing the NMDC EDG
 - `./README.md` - (You are here)
 - `./docker-compose.prod.yml` - A `docker-compose.yml` file designed to facilitate deploying the NMDC EDGE web
   application to a production* environment.
-  > *Note: Since we are still preparing the environment that will eventually host the production instance of NMDC EDGE,
-  > this file currently contains references to a development hostname instead of the production hostname.

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -26,7 +26,7 @@ version: "3"
 services:
   app:
     # Reference: https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app
-    image: ghcr.io/microbiomedata/nmdc-edge-web-app:commit-a8664570-node20-amd64
+    image: ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64
     restart: unless-stopped
     ports:
       - "8000:8000"

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -13,6 +13,9 @@ version: "3"
 #    $ export OAUTH_SECRET='...'
 #    $ export EMAIL_SHARED_SECRET='...'
 #
+#    # Note: You can generate a random 20-character string by running:
+#    $ openssl rand -base64 20
+#
 # 3. Spin up the stack.
 #    $ docker compose up --detach
 #

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -2,10 +2,11 @@ version: "3"
 
 ###############################################################################
 #
-# Usage:
+# Usage (on a VM):
 #
-# 1. Ensure the persistent volume for Mongo data exists:
+# 1. Ensure the necessary persistent volumes exists and are accessible:
 #    $ stat /media/volume/nmdc-edge-web-app-mongo-data
+#    $ stat /media/volume/nmdc-edge-web-app-io-data
 #
 # 2. Set environment variables:
 #    $ export JWT_SECRET='...'
@@ -16,14 +17,14 @@ version: "3"
 #    $ docker compose up --detach
 #
 #    # (Optional) View container logs.
-#    $ docker compose logs -f webapp
+#    $ docker compose logs -f app
 #    $ docker compose logs -f mongo
 #    $ docker compose logs -f caddy
 #
 ###############################################################################
 
 services:
-  webapp:
+  app:
     # Reference: https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app
     image: ghcr.io/microbiomedata/nmdc-edge-web-app:commit-a8664570-node20-amd64
     restart: unless-stopped
@@ -33,9 +34,13 @@ services:
     # Reference: https://github.com/docker/for-linux/issues/264#issuecomment-784985736
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    volumes:
+      - /media/volume/nmdc-edge-web-app-io-data:/io
     environment:
       DATABASE_HOST: mongo
       APP_EXTERNAL_BASE_URL: https://edge-dev.microbiomedata.org
+      # Set `IO_BASE_DIR` to the path at which the persistent volume is mounted (see `volumes` above).
+      IO_BASE_DIR: /io
       # These lines tell Docker to populate these _container_ environment variables (on left)
       # with the values of the corresponding _host_ environment variables (on right).
       JWT_SECRET: ${JWT_SECRET}
@@ -77,4 +82,4 @@ services:
       caddy reverse-proxy
         --access-log
         --from 'edge-dev.microbiomedata.org:443'
-        --to 'webapp:8000'
+        --to 'app:8000'

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -16,9 +16,9 @@ version: "3"
 #    $ docker compose up --detach
 #
 #    # (Optional) View container logs.
-#    $ docker logs -f webapp
-#    $ docker logs -f mongo
-#    $ docker logs -f caddy
+#    $ docker compose logs -f webapp
+#    $ docker compose logs -f mongo
+#    $ docker compose logs -f caddy
 #
 ###############################################################################
 

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -1,0 +1,80 @@
+version: "3"
+
+###############################################################################
+#
+# Usage:
+#
+# 1. Ensure the persistent volume for Mongo data exists:
+#    $ stat /media/volume/nmdc-edge-web-app-mongo-data
+#
+# 2. Set environment variables:
+#    $ export JWT_SECRET='...'
+#    $ export OAUTH_SECRET='...'
+#    $ export EMAIL_SHARED_SECRET='...'
+#
+# 3. Spin up the stack.
+#    $ docker compose up --detach
+#
+#    # (Optional) View container logs.
+#    $ docker logs -f webapp
+#    $ docker logs -f mongo
+#    $ docker logs -f caddy
+#
+###############################################################################
+
+services:
+  webapp:
+    # Reference: https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app
+    image: ghcr.io/microbiomedata/nmdc-edge-web-app:commit-a8664570-node20-amd64
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    # When the container host is Linux, this makes it so containers can access the host via `host.docker.internal`.
+    # Reference: https://github.com/docker/for-linux/issues/264#issuecomment-784985736
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      DATABASE_HOST: mongo
+      APP_EXTERNAL_BASE_URL: https://edge-dev.microbiomedata.org
+      # These lines tell Docker to populate these _container_ environment variables (on left)
+      # with the values of the corresponding _host_ environment variables (on right).
+      JWT_SECRET: ${JWT_SECRET}
+      OAUTH_SECRET: ${OAUTH_SECRET}
+      EMAIL_SHARED_SECRET: ${EMAIL_SHARED_SECRET}
+    depends_on:
+      - mongo
+      - caddy
+
+  mongo:
+    image: mongo:6.0.4
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    # Map a persistent volume to `/data/db` within the container.
+    volumes:
+      - /media/volume/nmdc-edge-web-app-mongo-data:/data/db
+
+  caddy:
+    image: caddy:2.7.6
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "80:80"
+      - "443:443"
+
+    # Run caddy as a reverse proxy.
+    #
+    # References:
+    # - https://caddyserver.com/docs/quick-starts/reverse-proxy
+    # - https://caddyserver.com/docs/command-line#caddy-reverse-proxy
+    #
+    # Note: The `>` character tells YAML to "fold" the newlines in the multiline string into spaces,
+    #       and the `-` after it tells YAML not to append a trailing newline to the resulting string.
+    #       Reference: https://yaml-multiline.info/
+    #
+    command: >-
+      caddy reverse-proxy
+        --access-log
+        --from 'edge-dev.microbiomedata.org:443'
+        --to 'webapp:8000'

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -13,6 +13,12 @@ version: "3"
 #    $ export OAUTH_SECRET='...'
 #    $ export EMAIL_SHARED_SECRET='...'
 #
+#    # (Optional) Override default values:
+#    $ export APP_IMAGE='...'
+#    $ export APP_EXTERNAL_HOSTNAME='...'
+#    $ export IO_BASE_DIR_ON_HOST='...'
+#    $ export MONGO_DATA_DIR_ON_HOST='...'
+#
 #    # Note: You can generate a random 20-character string by running:
 #    $ openssl rand -base64 20
 #
@@ -29,7 +35,7 @@ version: "3"
 services:
   app:
     # Reference: https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app
-    image: ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64
+    image: ${APP_IMAGE:-ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64}
     restart: unless-stopped
     ports:
       - "8000:8000"
@@ -38,10 +44,10 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - /media/volume/nmdc-edge-web-app-io-data:/io
+      - ${IO_BASE_DIR_ON_HOST:-/media/volume/nmdc-edge-web-app-io-data}:/io
     environment:
       DATABASE_HOST: mongo
-      APP_EXTERNAL_BASE_URL: https://edge-dev.microbiomedata.org
+      APP_EXTERNAL_BASE_URL: https://${APP_EXTERNAL_HOSTNAME:-edge-dev.microbiomedata.org}
       # Set `IO_BASE_DIR` to the path at which the persistent volume is mounted (see `volumes` above).
       IO_BASE_DIR: /io
       # These lines tell Docker to populate these _container_ environment variables (on left)
@@ -60,7 +66,7 @@ services:
       - "27017:27017"
     # Map a persistent volume to `/data/db` within the container.
     volumes:
-      - /media/volume/nmdc-edge-web-app-mongo-data:/data/db
+      - {$MONGO_DATA_DIR_ON_HOST:-/media/volume/nmdc-edge-web-app-mongo-data}:/data/db
 
   caddy:
     image: caddy:2.7.6
@@ -81,8 +87,11 @@ services:
     #       and the `-` after it tells YAML not to append a trailing newline to the resulting string.
     #       Reference: https://yaml-multiline.info/
     #
+    # Note: The `${ENV_VAR_NAME:-default_value}` syntax tells Docker to use the value of the specified environment
+    #       variable if that environment variable exists; otherwise, use the value that follows the `:-` delimiter.
+    #
     command: >-
       caddy reverse-proxy
         --access-log
-        --from 'edge-dev.microbiomedata.org:443'
+        --from '${APP_EXTERNAL_HOSTNAME:-edge-dev.microbiomedata.org}:443'
         --to 'app:8000'

--- a/webapp/server/config.js
+++ b/webapp/server/config.js
@@ -49,10 +49,11 @@ const makeIntIfDefined = (val) => {
     return typeof val === "string" ? parseInt(val, 10) : undefined;
 };
 
-// Determine several reusable directory paths based upon the directory containing this config file.
+// Determine several reusable directory paths based upon environment variables
+// and/or the path to the directory containing this `config.js` file.
 const CLIENT_BASE_DIR = path.join(__dirname, "../client");
 const DATA_BASE_DIR = path.join(__dirname, "../../data")
-const IO_BASE_DIR = path.join(__dirname, "../../io");
+const IO_BASE_DIR = process.env.IO_BASE_DIR || path.join(__dirname, "../../io");
 
 const config = {
     // Name of environment in which application is running (either "production" or "development").


### PR DESCRIPTION
In this branch, I created the `docker-compose.prod.yml` file, which is a "Docker compose" file designed for deploying the web app to a Jetstream2 VM or other Linux-based Docker host.

When running `docker compose up`, Docker will use the following environment variables, if defined on the Docker host:
- `APP_IMAGE`: The identifier of the published container image that can be used to run the web app
  - Default: `ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64`, which is currently the latest version of the container image
- `IO_BASE_DIR_ON_HOST`: The path (on the Docker host) at which the "IO" base directory is mounted. This will be mounted at `/io` within the web app container.
  - Default: `/media/volume/nmdc-edge-web-app-io-data`
- `APP_EXTERNAL_HOSTNAME`: The hostname part of the URL that end users will be able to use to access the web app
  - Default: `edge-dev.microbiomedata.org`
- `JWT_SECRET`: A secret string with which the web server will sign JWTs (JSON Web Tokens)
  - There is no default value. You can generate a value via: `$ openssl rand -base64 20`
- `OAUTH_SECRET`: A secret string with which the web server will "salt" submitted passwords
  - There is no default value. You can generate a value via: `$ openssl rand -base64 20`
- `EMAIL_SHARED_SECRET`: A secret string that clients can use to access the `/sendmail` endpoint
  - There is no default value. You can generate a value via: `$ openssl rand -base64 20`
- `MONGO_DATA_DIR_ON_HOST`: The path (on the Docker host) at which the Mongo data directory is mounted. In the MongoDB container, this will be mounted at `/data/db`, which is where MongoDB is configured to store its data.
  - Default: `/media/volume/nmdc-edge-web-app-mongo-data`

I also made a change to the web app. I updated the web app so that it uses the `IO_BASE_DIR` environment variable if it is defined within the container. I set its default value to `/io`, so that, by default, it refers to the same directory as the `IO_BASE_DIR_ON_HOST` environment variable on the Docker host.