### PR TITLE
Configure GitHub Actions to build and publish container image

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -30,7 +30,7 @@ jobs:
                   flavor: latest=false
                   tags: type=semver,pattern={{version}}
               # Use the `docker/build-push-action` action to build the image described
-              # by the `Dockerfile`. If the build succeeds, push the image to GHCR.
+              # by the specified Dockerfile. If the build succeeds, push the image to GHCR.
               # This action uses the `tags` and `labels` parameters to tag and label
               # the image, respectively, with the output from the "meta" step above.
               # For more info: https://github.com/docker/build-push-action#usage.
@@ -39,6 +39,7 @@ jobs:
               uses: docker/build-push-action@v5
               with:
                   context: .
+                  file: webapp-node20.Dockerfile
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,48 @@
+name: Build and push container image to GHCR
+
+# Run this workflow whenever a Release is published.
+on:
+    release:
+        types: [published]
+
+jobs:
+    build-and-push-image:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout branch
+              uses: actions/checkout@v4
+            - name: Authenticate with container registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+              # Use the `docker/metadata-action` action to extract values that can
+              # be incorporated into the tags and labels of the resulting container
+              # image. The step's `id` ("meta") can be used in subsequent steps to
+              # reference the output of this step.
+              # For more info: https://github.com/docker/metadata-action
+            - name: Prepare metadata of container image
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ghcr.io/microbiomedata/nmdc-edge-web-app
+                  flavor: latest=false
+                  tags: type=semver,pattern={{version}}
+              # Use the `docker/build-push-action` action to build the image described
+              # by the `Dockerfile`. If the build succeeds, push the image to GHCR.
+              # This action uses the `tags` and `labels` parameters to tag and label
+              # the image, respectively, with the output from the "meta" step above.
+              # For more info: https://github.com/docker/build-push-action#usage.
+            - name: Build and push container image
+              id: push
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+
+# References:
+# - https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+# - https://github.com/microbiomedata/nmdc-aggregator/blob/main/.github/workflows/build-and-push-image.yml


### PR DESCRIPTION
In this branch, I introduced a GitHub Actions workflow that will build the container image and push it to the `nmdc-edge-web-app` package repository—[here](https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app)—on GitHub Packages/GitHub Container Registry (GHCR).

The build-and-publish will happen whenever someone creates a GitHub Release of this project. The container image's tag will match the tag used for the release as long as the latter is formatted according to semantic versioning (e.g. a release tagged `v1.2.3` will yield a container image tag of `1.2.3`).

Once this branch has been merged into `main`, I'll demonstrate.