### PR TITLE
Ensure Caddy routes traffic to same port web app listens on

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,4 @@ This directory contains documentation and files related to managing the NMDC EDG
 ## Table of contents
 
 - `./README.md` - (You are here)
-- `./docker-compose.prod.yml` - A `docker-compose.yml` file designed to facilitate deploying the NMDC EDGE web
-  application to a production* environment.
+- `./docker-compose.prod.yml` - A `docker-compose.yml` file designed to facilitate deploying the NMDC EDGE web application to a production environment.

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -38,7 +38,7 @@ services:
     image: ${APP_IMAGE:-ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64}
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "8000:${APP_SERVER_PORT:-5000}"
     # When the container host is Linux, this makes it so containers can access the host via `host.docker.internal`.
     # Reference: https://github.com/docker/for-linux/issues/264#issuecomment-784985736
     extra_hosts:
@@ -94,4 +94,4 @@ services:
       caddy reverse-proxy
         --access-log
         --from '${APP_EXTERNAL_HOSTNAME:-edge-dev.microbiomedata.org}:443'
-        --to 'app:8000'
+        --to 'app:${APP_SERVER_PORT:-5000}'


### PR DESCRIPTION
In this branch, I made it so (a) the web app container, (b) the Caddy routing rule, and (c) the web app server application, all have the same default port number and all get their port number override (if any) from the same source.