### PR TITLE
Fix syntax error in `docker-compose.prod.yml`

### DIFF
--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -66,7 +66,7 @@ services:
       - "27017:27017"
     # Map a persistent volume to `/data/db` within the container.
     volumes:
-      - {$MONGO_DATA_DIR_ON_HOST:-/media/volume/nmdc-edge-web-app-mongo-data}:/data/db
+      - ${MONGO_DATA_DIR_ON_HOST:-/media/volume/nmdc-edge-web-app-mongo-data}:/data/db
 
   caddy:
     image: caddy:2.7.6


### PR DESCRIPTION
In this branch, I fixed a syntax error in the production "docker compose" file. The syntax error was the result of a typo.