### PR TITLE
Ensure the mapped container port and the Express server port remain consistent with one another

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,10 @@ services:
       JWT_SECRET: "jwt-secret"
       OAUTH_SECRET: "oauth-secret"
       EMAIL_SHARED_SECRET: "email-shared-secret"
-    # Map localhost port 8000 to container port 5000.
+    # Map localhost port 8000 to container port 5000 (the latter can
+    # be overriden via the `APP_SERVER_PORT` environment variable).
     ports:
-      - "8000:5000"
+      - "8000:${APP_SERVER_PORT:-5000}"
     depends_on:
       - mongo
       - cromwell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,9 @@ services:
       JWT_SECRET: "jwt-secret"
       OAUTH_SECRET: "oauth-secret"
       EMAIL_SHARED_SECRET: "email-shared-secret"
-    # Map localhost port 8000 to container port 8000.
+    # Map localhost port 8000 to container port 5000.
     ports:
-      - "8000:8000"
+      - "8000:5000"
     depends_on:
       - mongo
       - cromwell


### PR DESCRIPTION
In this branch, I updated the `docker-compose.yml` file used for the development environment—so that the port number of the `webapp` container that gets mapped to `localhost:8000` on the host is always consistent with the port number the Express app (running within that container) is listening on.