### PR TITLE
Implement API endpoint that returns app version identifier

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -43,6 +43,12 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  # Use the Git tag name as the application version identifier.
+                  # Here, we inject the Git tag name into the container image via
+                  # the `--build-arg` CLI option of `$ docker build`. Then, in the
+                  # Dockerfile, we consume it via the `ARG` keyword.
+                  build-args: |
+                    NMDC_EDGE_WEB_APP_VERSION=${{ github.ref_name }}
 
 # References:
 # - https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -44,9 +44,11 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   # Use the Git tag name as the application version identifier.
-                  # Here, we inject the Git tag name into the container image via
-                  # the `--build-arg` CLI option of `$ docker build`. Then, in the
-                  # Dockerfile, we consume it via the `ARG` keyword.
+                  # Here, we add a `--build-arg` CLI option to the `$ docker build`
+                  # command that runs during this step. In the Dockerfile, we
+                  # consume it via the `ARG` directive and then use the `ENV`
+                  # directive to assign it to an environment variable that will
+                  # exist within the container image.
                   build-args: |
                     NMDC_EDGE_WEB_APP_VERSION=${{ github.ref_name }}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,9 @@ services:
       JWT_SECRET: "jwt-secret"
       OAUTH_SECRET: "oauth-secret"
       EMAIL_SHARED_SECRET: "email-shared-secret"
+      NMDC_EDGE_WEB_APP_VERSION: v0.0.0-local
     # Map localhost port 8000 to container port 5000 (the latter can
-    # be overriden via the `APP_SERVER_PORT` environment variable).
+    # be overridden via the `APP_SERVER_PORT` environment variable).
     ports:
       - "8000:${APP_SERVER_PORT:-5000}"
     depends_on:

--- a/webapp-node16.Dockerfile
+++ b/webapp-node16.Dockerfile
@@ -11,6 +11,15 @@ FROM node:16-alpine
 LABEL org.opencontainers.image.description="NMDC EDGE Web App (Node v16)"
 LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-edge"
 
+# Create an environment variable that contains the web app version identifier.
+#
+# Note: Its value will come from the `--build-arg NMDC_EDGE_WEB_APP_VERSION={value}`
+#       CLI option, if any, included in the `$ docker build` command.
+#       Reference: https://docs.docker.com/reference/dockerfile/#arg
+#
+ARG NMDC_EDGE_WEB_APP_VERSION
+ENV NMDC_EDGE_WEB_APP_VERSION="$NMDC_EDGE_WEB_APP_VERSION"
+
 # Install programs upon which the web app or its build process(es) depend.
 #
 # Note: `apk` (Alpine Package Keeper) is the Alpine Linux equivalent of `apt`.

--- a/webapp-node18.Dockerfile
+++ b/webapp-node18.Dockerfile
@@ -11,6 +11,15 @@ FROM node:18-alpine
 LABEL org.opencontainers.image.description="NMDC EDGE Web App (Node v18)"
 LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-edge"
 
+# Create an environment variable that contains the web app version identifier.
+#
+# Note: Its value will come from the `--build-arg NMDC_EDGE_WEB_APP_VERSION={value}`
+#       CLI option, if any, included in the `$ docker build` command.
+#       Reference: https://docs.docker.com/reference/dockerfile/#arg
+#
+ARG NMDC_EDGE_WEB_APP_VERSION
+ENV NMDC_EDGE_WEB_APP_VERSION="$NMDC_EDGE_WEB_APP_VERSION"
+
 # Install programs upon which the web app or its build process(es) depend.
 #
 # Note: `apk` (Alpine Package Keeper) is the Alpine Linux equivalent of `apt`.

--- a/webapp-node20.Dockerfile
+++ b/webapp-node20.Dockerfile
@@ -11,6 +11,15 @@ FROM node:20-alpine
 LABEL org.opencontainers.image.description="NMDC EDGE Web App (Node v20)"
 LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-edge"
 
+# Create an environment variable that contains the web app version identifier.
+#
+# Note: Its value will come from the `--build-arg NMDC_EDGE_WEB_APP_VERSION={value}`
+#       CLI option, if any, included in the `$ docker build` command.
+#       Reference: https://docs.docker.com/reference/dockerfile/#arg
+#
+ARG NMDC_EDGE_WEB_APP_VERSION
+ENV NMDC_EDGE_WEB_APP_VERSION="$NMDC_EDGE_WEB_APP_VERSION"
+
 # Install programs upon which the web app or its build process(es) depend.
 #
 # Note: `apk` (Alpine Package Keeper) is the Alpine Linux equivalent of `apt`.

--- a/webapp/server/config.js
+++ b/webapp/server/config.js
@@ -67,6 +67,8 @@ const config = {
         SERVER_PORT: makeIntIfDefined(process.env.APP_SERVER_PORT) || 5000,
         // Path to the "docs" directory on the filesystem.
         DOCS_BASE_DIR: process.env.DOCS_BASE_DIR || path.join(DATA_BASE_DIR, "docs"),
+        // Version identifier of the application.
+        VERSION: process.env.NMDC_EDGE_WEB_APP_VERSION || "v0.0.0-default",
     },
     AUTH: {
         // A secret string with which the web server will sign JWTs (JSON Web Tokens).

--- a/webapp/server/server.js
+++ b/webapp/server/server.js
@@ -114,6 +114,10 @@ app.use(passport.initialize());
 require("./util/passport")(passport);
 
 // Routes
+app.get("/api/version", (req, res) => {
+  // Return the version identifier of the NMDC EDGE web application.
+  res.json({ version: config.APP.VERSION });
+});
 app.use("/api/user", user);
 app.use("/api/project", project);
 app.use("/auth-api/user", passport.authenticate('user', { session: false }), auth_user);


### PR DESCRIPTION
In this branch, I configured the GitHub Actions workflow that builds the container images, to store the application's version number in an environment variable within the container image. I also defined a new server-side `config` variable that reads that environment variable and makes its value available to the server-side application. Finally, I implemented an API endpoint (at `/api/version`) that returns the version identifier, which looks like this:

<img width="388" alt="image" src="https://github.com/microbiomedata/nmdc-edge/assets/134325062/3f504e38-5ad1-41c4-bcb0-b990bb02facb">

This gets us closer to allowing users to determine what version of NMDC EDGE they did something with (e.g. for citation purposes). Eventually, I suspect we will display the version identifier on the web UI, but that is out of scope for this PR.