### PR TITLE
Configure Docker to get `CROMWELL_API_BASE_URL` from host environment

### DIFF
--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -8,7 +8,7 @@ version: "3"
 #    $ stat /media/volume/nmdc-edge-web-app-mongo-data
 #    $ stat /media/volume/nmdc-edge-web-app-io-data
 #
-# 2. Set environment variables:
+# 2. Set environment variables or populate the relevant `.env` file(s).
 #    $ export JWT_SECRET='...'
 #    $ export OAUTH_SECRET='...'
 #    $ export EMAIL_SHARED_SECRET='...'
@@ -18,6 +18,7 @@ version: "3"
 #    $ export APP_EXTERNAL_HOSTNAME='...'
 #    $ export IO_BASE_DIR_ON_HOST='...'
 #    $ export MONGO_DATA_DIR_ON_HOST='...'
+#    $ export CROMWELL_API_BASE_URL='...'
 #
 #    # Note: You can generate a random 20-character string by running:
 #    $ openssl rand -base64 20
@@ -47,6 +48,7 @@ services:
       - ${IO_BASE_DIR_ON_HOST:-/media/volume/nmdc-edge-web-app-io-data}:/io
     environment:
       DATABASE_HOST: mongo
+      CROMWELL_API_BASE_URL: ${CROMWELL_API_BASE_URL}
       APP_EXTERNAL_BASE_URL: https://${APP_EXTERNAL_HOSTNAME:-edge-dev.microbiomedata.org}
       # Set `IO_BASE_DIR` to the path at which the persistent volume is mounted (see `volumes` above).
       IO_BASE_DIR: /io


### PR DESCRIPTION
Earlier today, @mflynn-lanl found that — when using the production Docker Compose file — the `app` container was not "taking on" (i.e. "inheriting") the value of the `CROMWELL_API_BASE_URL` environment variable defined on the Docker host. That was an oversight on my part, when creating the production Docker Compose file. In this branch, I made it so that value will propagate from the host to the container.