### PR TITLE
Allow developer to customize UID/GID for web app container

### DIFF
--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -39,7 +39,7 @@ services:
     image: ${APP_IMAGE:-ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64}
     # Alternatively, to build an image from a Dockerfile (which will allow you to specify args at build time):
     #build:
-    #  context: /path/to/folder/containing/Dockerfile
+    #  context: /path/to/repository/root/directory
     #  dockerfile: webapp-node20.Dockerfile
     #  args:
     #    - USER_ID: ${USER_ID:-60005}

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -37,15 +37,15 @@ services:
   app:
     # Reference: https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app
     image: ${APP_IMAGE:-ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64}
-    # Alternatively, to build an image from a Dockerfile (which will allow you to specify build-time args):
+    # Alternatively, to build an image from a Dockerfile (which will allow you to specify args at build time):
     #build:
     #  context: /path/to/folder/containing/Dockerfile
     #  dockerfile: webapp-node20.Dockerfile
     #  args:
-    #    - USER_ID=60005
-    #    - GROUP_ID=60005
-    #    - USER_NAME=webuser
-    #    - GROUP_NAME=webuser
+    #    - USER_ID: ${USER_ID:-60005}
+    #    - GROUP_ID: ${GROUP_ID:-60005}
+    #    - USER_NAME: ${USER_NAME:-webuser}
+    #    - GROUP_NAME: ${GROUP_NAME:-webuser}
     restart: unless-stopped
     ports:
       - "8000:${APP_SERVER_PORT:-5000}"

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -37,6 +37,15 @@ services:
   app:
     # Reference: https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app
     image: ${APP_IMAGE:-ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64}
+    # Alternatively, to build an image from a Dockerfile (which will allow you to specify build-time args):
+    #build:
+    #  context: /path/to/folder/containing/Dockerfile
+    #  dockerfile: webapp-node20.Dockerfile
+    #  args:
+    #    - USER_ID=60005
+    #    - GROUP_ID=60005
+    #    - USER_NAME=webuser
+    #    - GROUP_NAME=webuser
     restart: unless-stopped
     ports:
       - "8000:${APP_SERVER_PORT:-5000}"

--- a/webapp-node16.Dockerfile
+++ b/webapp-node16.Dockerfile
@@ -20,6 +20,13 @@ LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-ed
 ARG NMDC_EDGE_WEB_APP_VERSION
 ENV NMDC_EDGE_WEB_APP_VERSION="$NMDC_EDGE_WEB_APP_VERSION"
 
+# Allow the developer to (optionally) customize the ID and name of the user by which PM2 will
+# be launched; and the ID and name of the group to which that user will belong.
+ARG USER_ID=60005
+ARG GROUP_ID=60005
+ARG USER_NAME=webuser
+ARG GROUP_NAME=webuser
+
 # Install programs upon which the web app or its build process(es) depend.
 #
 # Note: `apk` (Alpine Package Keeper) is the Alpine Linux equivalent of `apt`.
@@ -77,6 +84,17 @@ RUN cd webapp/client && npm run build
 # Build the web app server (e.g. Express app).
 #
 RUN cd webapp/server && npm ci
+
+# Create a group having the specified GID (Group ID) and group name, and create
+# a user (in that group) having the specified UID (User ID) and user name.
+# Reference: https://gist.github.com/utkuozdemir/3380c32dfee472d35b9c3e39bc72ff01
+RUN addgroup -g $GROUP_ID $GROUP_NAME && \
+    adduser --shell /sbin/nologin --disabled-password \
+            --ingroup $GROUP_NAME --uid $USER_ID $USER_NAME
+
+# Switch to that user before running the subsequent commands.
+# Reference: https://docs.docker.com/reference/dockerfile/#user
+USER $USER_NAME
 
 # Run PM2 in the foreground. PM2 will serve the NMDC EDGE web app.
 #


### PR DESCRIPTION
In this branch, I made it so the developer can customize which user PM2 is launched as within the web app container. I also included a commented-out sample snippet in the `docker-compose.prod.yml` file to facilitate the use of a spontaneously-built image instead of an image present in a registry.