### PR TITLE
Use `ORCID_CLIENT_ID` variable when building React app

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -51,7 +51,10 @@ jobs:
                   # exist within the container image.
                   build-args: |
                     NMDC_EDGE_WEB_APP_VERSION=${{ github.ref_name }}
+                    REACT_APP_IS_ORCID_AUTH_ENABLED=true
+                    REACT_APP_ORCID_CLIENT_ID=${{ vars.ORCID_CLIENT_ID }}
 
 # References:
+# - https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values
 # - https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
 # - https://github.com/microbiomedata/nmdc-aggregator/blob/main/.github/workflows/build-and-push-image.yml

--- a/webapp-node16.Dockerfile
+++ b/webapp-node16.Dockerfile
@@ -20,6 +20,13 @@ LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-ed
 ARG NMDC_EDGE_WEB_APP_VERSION
 ENV NMDC_EDGE_WEB_APP_VERSION="$NMDC_EDGE_WEB_APP_VERSION"
 
+# Create ORCID-related environment variables Node.js will consume while building the React app.
+ARG IS_ORCID_AUTH_ENABLED
+ENV REACT_APP_IS_ORCID_AUTH_ENABLED="$IS_ORCID_AUTH_ENABLED"
+
+ARG ORCID_CLIENT_ID
+ENV REACT_APP_ORCID_CLIENT_ID="$ORCID_CLIENT_ID"
+
 # Allow the developer to (optionally) customize the ID and name of the user by which PM2 will
 # be launched; and the ID and name of the group to which that user will belong.
 ARG USER_ID=60005

--- a/webapp-node18.Dockerfile
+++ b/webapp-node18.Dockerfile
@@ -20,6 +20,13 @@ LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-ed
 ARG NMDC_EDGE_WEB_APP_VERSION
 ENV NMDC_EDGE_WEB_APP_VERSION="$NMDC_EDGE_WEB_APP_VERSION"
 
+# Create ORCID-related environment variables Node.js will consume while building the React app.
+ARG IS_ORCID_AUTH_ENABLED
+ENV REACT_APP_IS_ORCID_AUTH_ENABLED="$IS_ORCID_AUTH_ENABLED"
+
+ARG ORCID_CLIENT_ID
+ENV REACT_APP_ORCID_CLIENT_ID="$ORCID_CLIENT_ID"
+
 # Allow the developer to (optionally) customize the ID and name of the user by which PM2 will
 # be launched; and the ID and name of the group to which that user will belong.
 ARG USER_ID=60005

--- a/webapp-node20.Dockerfile
+++ b/webapp-node20.Dockerfile
@@ -20,6 +20,13 @@ LABEL org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-ed
 ARG NMDC_EDGE_WEB_APP_VERSION
 ENV NMDC_EDGE_WEB_APP_VERSION="$NMDC_EDGE_WEB_APP_VERSION"
 
+# Create ORCID-related environment variables Node.js will consume while building the React app.
+ARG IS_ORCID_AUTH_ENABLED
+ENV REACT_APP_IS_ORCID_AUTH_ENABLED="$IS_ORCID_AUTH_ENABLED"
+
+ARG ORCID_CLIENT_ID
+ENV REACT_APP_ORCID_CLIENT_ID="$ORCID_CLIENT_ID"
+
 # Allow the developer to (optionally) customize the ID and name of the user by which PM2 will
 # be launched; and the ID and name of the group to which that user will belong.
 ARG USER_ID=60005


### PR DESCRIPTION
In this branch, I updated a GitHub Actions workflow and the Dockerfiles so that, when the React app gets built (while the GitHub Actions workflow is running), the builder has access to the value of a GitHub repo-level variable named `ORCID_CLIENT_ID`.

Separately, I will create a ticket requesting that @mflynn-lanl or @yxu-lanl create such a GitHub repo-level variable, as I do not have sufficient permissions in this repo.