### PR TITLE
Make `build-args` names consistent with `ARG` names in `Dockerfile`

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -51,8 +51,8 @@ jobs:
                   # exist within the container image.
                   build-args: |
                     NMDC_EDGE_WEB_APP_VERSION=${{ github.ref_name }}
-                    REACT_APP_IS_ORCID_AUTH_ENABLED=true
-                    REACT_APP_ORCID_CLIENT_ID=${{ vars.ORCID_CLIENT_ID }}
+                    IS_ORCID_AUTH_ENABLED=true
+                    ORCID_CLIENT_ID=${{ vars.ORCID_CLIENT_ID }}
 
 # References:
 # - https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values


### PR DESCRIPTION
In this branch, I fixed a bug where the names of the arguments defined in the GitHub Actions workflow were not consistent with the ones in the `Dockerfile`s. That bug was preventing Docker from using the values of those arguments when building the web app client.