### PR TITLE
66 implement new meta g qc visualizations

### DIFF
--- a/data/workflow/WDL/metaG/mbin_nmdc.wdl
+++ b/data/workflow/WDL/metaG/mbin_nmdc.wdl
@@ -404,6 +404,7 @@ task finish_mags {
         ln ${heatmap} ${prefix}_heatmap.pdf
         ln ${kronaplot} ${prefix}_kronaplot.html
         ln ${ko_matrix} ${prefix}_ko_matrix.txt
+        ln ${eukcc_file} ${prefix}_eukcc.csv
 
         # cp all tarfiles, zip them under prefix, if empty touch no_mags.txt
         mkdir -p hqmq
@@ -414,18 +415,18 @@ task finish_mags {
         else
             (cd hqmq && touch no_hqmq_mags.txt)
             (cd hqmq && cp ${mbin_sdb} .)
-            (cd hqmq && zip ../${prefix}_hqmq_bin.zip *.txt mbin.sdb)
+            (cd hqmq && zip -j ../${prefix}_hqmq_bin.zip *.txt mbin.sdb)
         fi
 
         mkdir -p lq
         if [ ${n_lq} -gt 0 ] ; then
             (cd lq && cp ${sep=" " lq_bin_tarfiles} .)
             (cd lq && cp ${mbin_sdb} .)
-            (cd lq && zip -j ../${prefix}_lq_bin.zip *tar.gz mbin.sdb ../*pdf ../*kronaplot.html ../*ko_matrix.txt)
+            (cd lq && zip -j ../${prefix}_lq_bin.zip *tar.gz mbin.sdb ${prefix}_eukcc.csv ../*pdf ../*kronaplot.html ../*ko_matrix.txt)
         else
             (cd lq && touch no_lq_mags.txt)
             (cd lq && cp ${mbin_sdb} .)
-            (cd lq && zip ../${prefix}_lq_bin.zip *.txt mbin.sdb)
+            (cd lq && zip -j ../${prefix}_lq_bin.zip *.txt mbin.sdb ${prefix}_eukcc.csv)
         fi
 
         # Fix up attribute name

--- a/data/workflow/WDL/metaG/readsqc_output.wdl
+++ b/data/workflow/WDL/metaG/readsqc_output.wdl
@@ -21,7 +21,7 @@ workflow readsqc_output {
         input: outdir=outdir,
         filtered= input_files,
         filtered_stats2_final=filtered_stats2_final,
-        container=bbtools_container
+        container=vis_container
     }
 }
 

--- a/data/workflow/WDL/metaG/readsqc_output.wdl
+++ b/data/workflow/WDL/metaG/readsqc_output.wdl
@@ -45,7 +45,7 @@ task fastqc_report{
 			prefix=${dollar}{f%_filtered.fastq.gz}
             fastqc -q -o output --dir $PWD $i
             mkdir -p ${outdir}/$prefix
-            qc_summary.py --input ~/Downloads/stats.txt  --output ${outdir}/$prefix/qc_summary.html
+            qc_summary.py --input $dir/${dollar}{prefix}_filterStats2.txt  --output ${outdir}/$prefix/qc_summary.html
         done
 
         multiqc -z -o output output

--- a/data/workflow/WDL/metaG/readsqc_output.wdl
+++ b/data/workflow/WDL/metaG/readsqc_output.wdl
@@ -6,6 +6,7 @@ workflow readsqc_output {
     Array[File] filtered_stats_json_final
     String? outdir
     String bbtools_container="microbiomedata/bbtools:38.96"
+    String vis_container="microbiomedata/fastqc_vis:1.0"
 
     call make_output {
         input: outdir=outdir,
@@ -16,6 +17,50 @@ workflow readsqc_output {
         filtered_stats_json_final=filtered_stats_json_final,
         container=bbtools_container
     }
+    call fastqc_report {
+        input: outdir=outdir,
+        filtered= input_files,
+        filtered_stats2_final=filtered_stats2_final,
+        container=bbtools_container
+    }
+}
+
+
+task fastqc_report{
+    String outdir
+    Array[File] filtered
+    Array[File] filtered_stats2_final
+    String container
+    String dollar ="$"
+
+    command<<<
+        set -euo pipefail
+
+        mkdir -p output
+
+        for i in ${sep=' ' filtered}
+        do
+            f=${dollar}(basename $i)
+			dir=${dollar}(dirname $i)
+			prefix=${dollar}{f%_filtered.fastq.gz}
+            fastqc -q -o output --dir $PWD $i
+            mkdir -p ${outdir}/$prefix
+            qc_summary.py --input ~/Downloads/stats.txt  --output ${outdir}/$prefix/qc_summary.html
+        done
+
+        multiqc -z -o output output
+
+        cp output/multiqc_report.html ${outdir}/multiqc_report.html
+    >>>
+
+	runtime {
+        docker: container
+        memory: "1 GiB"
+        cpu:  1
+    }
+	output{
+		File fastqc_html = "${outdir}/multiqc_report.html"
+	}
 }
 
 task make_output{
@@ -29,6 +74,7 @@ task make_output{
 	String container
 
  	command<<<
+            set -euo pipefail
 			mkdir -p ${outdir}
             for i in ${sep=' ' filtered}
 			do

--- a/data/workflow/WDL/metaG/rqcfilter.wdl
+++ b/data/workflow/WDL/metaG/rqcfilter.wdl
@@ -95,7 +95,7 @@ task rqcfilter {
             memory: "70 GB"
             cpu:  16
             database: database
-            runtime_minutes: ceil(size(input_files, "GB")*60)
+            #runtime_minutes: ceil(size(input_files, "GB")*60)
      }
 
      command<<<

--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -67,7 +67,8 @@ workflow main_workflow {
 	call readsqc_output.fastqc_report as fastqc_report {
 		input:
 		  outdir=readsQC_outdir,
-		  filtered= nmdc_rqcfilter_call.filtered_final,
+		  filtered=nmdc_rqcfilter_call.filtered_final,
+		  filtered_stats2_final=nmdc_rqcfilter_call.filtered_stats2_final,
 		  container=readsQC_vis_container
 	}
 

--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -66,10 +66,9 @@ workflow main_workflow {
 
 	call readsqc_output.fastqc_report as fastqc_report {
 		input:
-			input: outdir=readsQC_outdir,
-			filtered= nmdc_rqcfilter_call.filtered_final,
-			container=readsQC_vis_container
-
+		  outdir=readsQC_outdir,
+		  filtered= nmdc_rqcfilter_call.filtered_final,
+		  container=readsQC_vis_container
 	}
 
 	## ReadbasedAnalysis workflow

--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -60,13 +60,14 @@ workflow main_workflow {
                 database=readsQC_database,
                 proj=proj,
                 chastityfilter_flag=readsqc_preprocess.isIllumina
-       }
+		}
 
     }
 
 	call readsqc_output.fastqc_report as fastqc_report {
 		input:
 		  outdir=readsQC_outdir,
+		  input_files_prefix = readsqc_preprocess.input_files_prefix,
 		  filtered=nmdc_rqcfilter_call.filtered_final,
 		  filtered_stats2_final=nmdc_rqcfilter_call.filtered_stats2_final,
 		  container=readsQC_vis_container
@@ -87,11 +88,11 @@ workflow main_workflow {
 	String db_gottcha2 = "/refdata/GOTTCHA2_fungal/gottcha_db.BAVFPt.species.fna"
 	String db_kraken2 = "/refdata/Kraken2"
 	String db_centrifuge = "/refdata/Centrifuge/hpv"
-
+    
 	call readbasedanalysis_preprocess.preprocess as readbased_preprocess {
-    	input:
-        	input_files=readbasedAnalysis_reads,
-        	paired=readbasedAnalysis_paired
+	input:
+		input_files=readbasedAnalysis_reads,
+		paired=readbasedAnalysis_paired
 	}
 
     call readbasedAnalysis.ReadbasedAnalysis as ReadbasedAnalysis_call {
@@ -264,6 +265,7 @@ workflow main_workflow {
 			url_base=url_base,
 			git_url=git_url,
 			informed_by=informed_by,
+			input_files_prefix = readsqc_preprocess.input_files_prefix,
 			read = if (input_interleaved) then input_files else flatten([input_fq1,input_fq2]),
 			filtered = nmdc_rqcfilter_call.filtered_final,
 			filtered_stats = nmdc_rqcfilter_call.filtered_stats_final,
@@ -411,6 +413,8 @@ task finish {
 	String url_base
 	String git_url
 	Array[File] read
+	Array[String] input_files_prefix
+	Int file_num = length(input_files_prefix)
 	Array[File?] filtered
 	Array[File?] filtered_stats
 	Array[File?] filtered_stats2
@@ -498,20 +502,19 @@ task finish {
 				${select_first(filtered)} 'Filtered Reads' \
 				${select_first(filtered_stats)} 'Filtered Stats'
 			cp activity.json data_objects.json ${qadir}/
-            for i in ${sep=' ' filtered}
+			ARRAYPrefix=(${sep=" " input_files_prefix})
+			ARRAYFastq=(${sep=" " filtered})
+			for (( i = 0; i < ${file_num}; i++ ))
 			do
-				f=${dollar}(basename $i)
-				dir=${dollar}(dirname $i)
-				prefix=${dollar}{f%_filtered.fastq.gz}
+				f=${dollar}(basename ${dollar}{ARRAYPrefix[$i]})
+				dir=${dollar}(dirname ${dollar}{ARRAYFastq[$i]})
+				prefix=${dollar}{ARRAYPrefix[$i]}
 				mkdir -p ${qadir}/$prefix
-                cp -f $i ${qadir}/$prefix
-                cp -f $dir/${dollar}{prefix}_filterStats.txt  ${qadir}/$prefix/filterStats.txt
-                cp -f $dir/${dollar}{prefix}_filterStats2.txt  ${qadir}/$prefix/filterStats2.txt
-                cp -f $dir/${dollar}{prefix}_qa_stats.json ${qadir}/$prefix/filterStats.json
-
-            done
-
-		
+				cp -f ${dollar}{ARRAYFastq[$i]} ${qadir}/$prefix/$prefix.filtered.fastq.gz
+				cp -f $dir/*filterStats.txt  ${qadir}/$prefix/filterStats.txt
+				cp -f $dir/*filterStats2.txt  ${qadir}/$prefix/filterStats2.txt
+				cp -f $dir/*qa_stats.json ${qadir}/$prefix/filterStats.json
+			done
 
 			# Generate assembly objects
 			/scripts/generate_objects.py --type "assembly" --id ${informed_by} \

--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -1,5 +1,6 @@
 import "rqcfilter.wdl" as readsQC
 import "readsqc_preprocess.wdl" as readsqc_preprocess
+import "readsqc_output.wdl" as readsqc_output
 import "ReadbasedAnalysis.wdl" as readbasedAnalysis
 import "readbasedanalysis_preprocess.wdl" as readbasedanalysis_preprocess
 import "readbasedAnalysis_output.wdl" as readbasedAnalysis_output
@@ -35,6 +36,7 @@ workflow main_workflow {
 	## QC workflow
 	String? readsQC_outdir
 	String readsQC_bbtools_container="microbiomedata/bbtools:38.96"
+	String readsQC_vis_container="microbiomedata/fastqc_vis:1.0"
 	String readsQC_database="/refdata"
 	String readsQC_memory="60g"
 	String readsQC_threads="4"
@@ -61,6 +63,14 @@ workflow main_workflow {
        }
 
     }
+
+	call readsqc_output.fastqc_report as fastqc_report {
+		input:
+			input: outdir=readsQC_outdir,
+			filtered= nmdc_rqcfilter_call.filtered_final,
+			container=readsQC_vis_container
+
+	}
 
 	## ReadbasedAnalysis workflow
 	Map[String, Boolean] readbasedAnalysis_enabled_tools = {

--- a/data/workflow/templates/readsQC_wdl.tmpl
+++ b/data/workflow/templates/readsQC_wdl.tmpl
@@ -32,6 +32,7 @@ scatter (file in select_first([readsqc_preprocess.input_files_gz, [""]])) {
 
 call <WORKFLOW>_output.readsqc_output as readsqc_output {
     input:
+        input_files_prefix = readsqc_preprocess.input_files_prefix,
         input_files = nmdc_rqcfilter.filtered_final,
         filtered_stats_final = nmdc_rqcfilter.filtered_stats_final,
         filtered_stats2_final = nmdc_rqcfilter.filtered_stats2_final,


### PR DESCRIPTION
* Fixed multiple input fastq file QC which were overwritten by the same output name (project name) and same subdirectory.  Now, the output is named by the input prefix. 
* A qc_summary.html for each input fastq and a mutlitQC_report.html (filtered reads) have been added to metaG QC result.

<img width="912" alt="image" src="https://github.com/microbiomedata/nmdc-edge/assets/737589/deef37cc-135b-4ff9-96a1-e69acf7eae96">



- metaG project:
https://dev.nmdc-edge.org/public/project?code=BHgZNjOuX6l3SwGQ
  - mutlitQC result html:
  https://dev.nmdc-edge.org/projects/BHgZNjOuX6l3SwGQ/output/ReadsQC/multiqc_report.html
  - qc_summary html:
  https://dev.nmdc-edge.org/projects/BHgZNjOuX6l3SwGQ/output/ReadsQC/SRR7877884-int/qc_summary.html

- QC only project: 
https://dev.nmdc-edge.org/public/project?code=3aWRHC6uE45mh9z6

I think the qc_summary can replace the current json/table. @yxu-lanl.


