### PR TITLE
248 fix rqc input error

### DIFF
--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -72,6 +72,17 @@ workflow main_workflow {
 		  container=readsQC_vis_container
 	}
 
+	call readsqc_output.make_output as make_output {
+	    input:
+		  outdir=readsQC_outdir,
+		  filtered=nmdc_rqcfilter_call.filtered_final,
+          filtered_stats_final=nmdc_rqcfilter_call.filtered_stats_final,
+		  filtered_stats2_final=nmdc_rqcfilter_call.filtered_stats2_final,
+          filtered_stats_json_final = nmdc_rqcfilter_call.filtered_stats_json_final,
+          rqc_info = nmdc_rqcfilter_call.rqc_info,
+		  container=readsQC_vis_container
+	}
+
 	## ReadbasedAnalysis workflow
 	Map[String, Boolean] readbasedAnalysis_enabled_tools = {
 		"gottcha2": true,

--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -67,7 +67,6 @@ workflow main_workflow {
 	call readsqc_output.fastqc_report as fastqc_report {
 		input:
 		  outdir=readsQC_outdir,
-		  input_files_prefix = readsqc_preprocess.input_files_prefix,
 		  filtered=nmdc_rqcfilter_call.filtered_final,
 		  filtered_stats2_final=nmdc_rqcfilter_call.filtered_stats2_final,
 		  container=readsQC_vis_container

--- a/data/workflow/templates/readsQC_wdl.tmpl
+++ b/data/workflow/templates/readsQC_wdl.tmpl
@@ -32,7 +32,6 @@ scatter (file in select_first([readsqc_preprocess.input_files_gz, [""]])) {
 
 call <WORKFLOW>_output.readsqc_output as readsqc_output {
     input:
-        input_files_prefix = readsqc_preprocess.input_files_prefix,
         input_files = nmdc_rqcfilter.filtered_final,
         filtered_stats_final = nmdc_rqcfilter.filtered_stats_final,
         filtered_stats2_final = nmdc_rqcfilter.filtered_stats2_final,


### PR DESCRIPTION
I needed to make some changes to the ReadsQC output for the metaG pipeline. The output was missing the `metagenome_workflow/filterStats.json` which the website needed. I also added missing commas in the ReadsQC_wdl.tmpl file 