### PR TITLE
Configure Mongo to require authentication, and update app accordingly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     environment:
       DATABASE_HOST: mongo
       DATABASE_PORT: 27017
+      DATABASE_USERNAME: root
+      DATABASE_PASSWORD: password
       APP_EXTERNAL_BASE_URL: http://localhost:8000
       CROMWELL_API_BASE_URL: http://cromwell:8000
       JWT_SECRET: "jwt-secret"
@@ -52,6 +54,9 @@ services:
   mongo:
     image: mongo
     restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
     volumes:
       # Note: By default, the MongoDB server will store its data in `/data/db`.
       - mongo-data:/data/db

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -12,6 +12,8 @@ version: "3"
 #    $ export JWT_SECRET='...'
 #    $ export OAUTH_SECRET='...'
 #    $ export EMAIL_SHARED_SECRET='...'
+#    $ export DATABASE_USERNAME='...'
+#    $ export DATABASE_PASSWORD='...'
 #
 #    # (Optional) Override default values:
 #    $ export APP_IMAGE='...'
@@ -59,6 +61,8 @@ services:
       - ${IO_BASE_DIR_ON_HOST:-/media/volume/nmdc-edge-web-app-io-data}:/project/io
     environment:
       DATABASE_HOST: mongo
+      DATABASE_USERNAME: ${DATABASE_USERNAME}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
       CROMWELL_API_BASE_URL: ${CROMWELL_API_BASE_URL}
       APP_EXTERNAL_BASE_URL: https://${APP_EXTERNAL_HOSTNAME:-edge-dev.microbiomedata.org}
       # Set `IO_BASE_DIR` to the path at which the persistent volume is mounted (see `volumes` above).
@@ -77,6 +81,9 @@ services:
   mongo:
     image: mongo:6.0.4
     restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${DATABASE_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${DATABASE_PASSWORD}
     ports:
       - "27017:27017"
     # Map a persistent volume to `/data/db` within the container.

--- a/webapp/server/config.js
+++ b/webapp/server/config.js
@@ -119,7 +119,12 @@ const config = {
         SERVER_HOST: process.env.DATABASE_HOST || "localhost",
         // Port at which web server can access MongoDB server (on the specified host).
         SERVER_PORT: makeIntIfDefined(process.env.DATABASE_PORT) || 27017,
+        // Credentials with which the web server can authenticate with the MongoDB server.
+        USERNAME: process.env.DATABASE_USERNAME,
+        PASSWORD: process.env.DATABASE_PASSWORD,
         // Name of MongoDB database.
+        // TODO: Update environment variable name to `DATABASE_NAME` to be more similar to other environment variables.
+        //       Note: That will require coordination with the people that manage the various deployments of this app.
         NAME: process.env.DB_NAME || "nmdcedge",
         // Path to directory in which the system will store the database backups it creates.
         BACKUP_DIR: process.env.DATABASE_BACKUP_DIR || path.join(IO_BASE_DIR, "db"),

--- a/webapp/server/cronserver.js
+++ b/webapp/server/cronserver.js
@@ -27,10 +27,17 @@ const db = `mongodb://${config.DATABASE.SERVER_HOST}:${config.DATABASE.SERVER_PO
 mongoose
   .connect(
     db,
-    { useCreateIndex: true, useNewUrlParser: true, useUnifiedTopology: true }
+    {
+      authSource: "admin",
+      user: config.DATABASE.USERNAME,
+      pass: config.DATABASE.PASSWORD,
+      useCreateIndex: true,
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    }
   )
   .then(() => logger.info("MongoDB successfully connected"))
-  .catch(err => logger.error(err));
+  .catch(err => logger.error("Failed to connect to MongoDB server:", err));
 
 //cron jobs
 // monitor pipeline requests on every 1 minute

--- a/webapp/server/server.js
+++ b/webapp/server/server.js
@@ -125,10 +125,17 @@ const db = `mongodb://${config.DATABASE.SERVER_HOST}:${config.DATABASE.SERVER_PO
 mongoose
   .connect(
     db,
-    { useCreateIndex: true, useNewUrlParser: true, useUnifiedTopology: true }
+    {
+      authSource: "admin",
+      user: config.DATABASE.USERNAME,
+      pass: config.DATABASE.PASSWORD,
+      useCreateIndex: true,
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    }
   )
   .then(() => logger.info("MongoDB successfully connected"))
-  .catch(err => logger.error(err));
+  .catch(err => logger.error("Failed to connect to MongoDB server:", err));
 
 // Passport middleware
 app.use(passport.initialize());


### PR DESCRIPTION
### Summary of changes

In this branch, I updated the MongoDB server's configuration for both the local development and the production environments, so that the MongoDB server requires authentication (i.e. a username and password). I also updated the web app server to provide credentials to the MongoDB server when the former tries to connect to the latter.

### Deployment notes

Before deploying this to SDSC, create a pair of environment variables on the Docker host:

```shell
DATABASE_USERNAME=root
DATABASE_PASSWORD=... # something from: https://bitwarden.com/password-generator/#password-generator
```

Before deploying this to Jetstream2, do the same thing. Also, the Mongo container won't actually create the associated user if Mongo's data directory already contains a database.

From the container image [docs](https://hub.docker.com/_/mongo): 
> Do note that [none of those environment variables] will have any effect if you start the container with a data directory that already contains a database...

So, if Mongo's data directory does contain a database, either delete that database or [manually create the user via mongosh](https://gist.github.com/ramonfritsch/2cb12f6b94e145451b6e#file-gistfile1-txt-L1-L8). In the case of our current Jetstream2 deployment, I'd recommend bringing down the Docker Compose stack and then deleting everything in the `/media/volume/nmdc-edge-web-app-mongo-data` directory on the web app VM.