### PR TITLE
Display error details instead of `[object Object]`

### DIFF
--- a/webapp/server/routes/auth-api/user.js
+++ b/webapp/server/routes/auth-api/user.js
@@ -512,9 +512,8 @@ router.post("/upload/add", (req, res) => {
                     const file = req.files.file;
                     file.mv(`${upload_home}`, errorObject => {
                         if (errorObject) {
-                            // Propagate this exception to the outer scope,
-                            // so it gets handled in a standard way.
-                            throw errorObject;
+                            logger.error(JSON.stringify(errorObject));
+                            return res.status(500).json(sysError);
                         }
                         logger.debug("upload:" + `${upload_home}`);
                         return res.json({


### PR DESCRIPTION
In this branch, I fixed an issue where the server console would show `[object Object]` instead of the details of the error that had occurred. Now, the server console will show the latter.

I also updated some other error displaying code (still on the server side) to include more details about the error.

Finally, I updated an HTTP response so that it would not expose a server-side stack trace, given that that could contain sensitive information (e.g. absolute file paths).

Fixes #288