### PR TITLE
Replace Caddy with Nginx and generate self-signed SSL certificate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,39 @@
 
 This directory contains documentation and files related to managing the NMDC EDGE web application.
 
-## Table of contents
+## Files
 
 - `./README.md` - (You are here)
 - `./docker-compose.prod.yml` - A `docker-compose.yml` file designed to facilitate deploying the NMDC EDGE web application to a production environment.
+- `./nginx-default.conf.template` - An Nginx configuration file in which variable names will be replaced with their values.
+- `./create_ssl_cert.sh` - A shell script designed to generate a self-signed SSL certificate when the `nginx` container starts up.
+- `./initialize_vm_on_jetstream2.sh` - A shell script designed to facilitate initializing the Docker host (i.e. the Jetstream2 VM that will run Docker).
+
+## Appendix
+
+Here's a command you can run in order to download the `docker-compose.prod.yml` file onto the VM:
+
+```shell
+curl -o ./docker-compose.yml https://raw.githubusercontent.com/microbiomedata/nmdc-edge/main/docs/docker-compose.prod.yml
+```
+> The downloaded file will be named: `docker-compose.yml`
+
+Here's a command you can run in order to download the `nginx-default.conf.template` file onto the VM:
+
+```shell
+curl -o ./nginx-default.conf.template https://raw.githubusercontent.com/microbiomedata/nmdc-edge/main/docs/nginx-default.conf.template
+```
+
+Here's a sequence of commands you can run in order to download the `create_ssl_cert.sh` script onto the VM and make it executable:
+
+```shell
+curl  -o create_ssl_cert.sh https://raw.githubusercontent.com/microbiomedata/nmdc-edge/main/docs/create_ssl_cert.sh
+chmod +x create_ssl_cert.sh
+```
+
+Here's a sequence of commands you can run in order to download the `initialize_vm_on_jetstream2.sh` script onto the VM and make it executable:
+
+```shell
+curl  -o initialize_vm.sh https://raw.githubusercontent.com/microbiomedata/nmdc-edge/main/docs/initialize_vm_on_jetstream2.sh
+chmod +x initialize_vm.sh
+```

--- a/docs/create_ssl_cert.sh
+++ b/docs/create_ssl_cert.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+###############################################################################
+# This shell script creates a self-signed SSL certificate.
+# Reference: https://typeofnan.dev/a-one-line-command-to-generate-a-self-signed-ssl-certificate/
+###############################################################################
+
+echo "Creating self-signed SSL certificate..."
+echo
+
+openssl \
+  req -nodes -new -x509 \
+  -keyout /root/ssl.crt.key \
+  -out /root/ssl.crt \
+  -subj='/C=US'
+
+echo "Done"
+echo

--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -18,6 +18,7 @@ version: "3"
 #    # (Optional) Override default values:
 #    $ export APP_IMAGE='...'
 #    $ export APP_EXTERNAL_HOSTNAME='...'
+#    $ export APP_INTERNAL_HOSTNAME='...'
 #    $ export IO_BASE_DIR_ON_HOST='...'
 #    $ export MONGO_DATA_DIR_ON_HOST='...'
 #    $ export CROMWELL_API_BASE_URL='...'
@@ -33,12 +34,13 @@ version: "3"
 #    # (Optional) View container logs.
 #    $ docker compose logs -f app
 #    $ docker compose logs -f mongo
-#    $ docker compose logs -f caddy
+#    $ docker compose logs -f nginx
 #
 ###############################################################################
 
 services:
   app:
+    container_name: app
     # Reference: https://github.com/microbiomedata/nmdc-edge/pkgs/container/nmdc-edge-web-app
     image: ${APP_IMAGE:-ghcr.io/microbiomedata/nmdc-edge-web-app:commit-ff4a1fe2-node20-amd64}
     # Alternatively, to build an image from a Dockerfile (which will allow you to specify args at build time):
@@ -76,7 +78,7 @@ services:
       EMAIL_SHARED_SECRET: ${EMAIL_SHARED_SECRET}
     depends_on:
       - mongo
-      - caddy
+      - nginx
 
   mongo:
     image: mongo:6.0.4
@@ -90,30 +92,27 @@ services:
     volumes:
       - ${MONGO_DATA_DIR_ON_HOST:-/media/volume/nmdc-edge-web-app-mongo-data}:/data/db
 
-  caddy:
-    image: caddy:2.7.6
+  nginx:
+    image: nginx  # docs: https://hub.docker.com/_/nginx
     restart: unless-stopped
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    environment:
+      # Note: The `SERVER_NAME` environment variable contains the hostname that Cloudflare, itself, uses
+      #       to access our web server. This is typically something provided by the infrastructure provider
+      #       (e.g. Jetstream2). This may be different from the hostname that end users use to access our
+      #       web server via Cloudflare (which then proxies their requests to our web server).
+      #       Here's a graphical representation showing where different hostnames come into play:
+      #       User → "External hostname" → Cloudflare → "Internal hostname" (this) → Nginx → Web app
+      #
+      SERVER_NAME: ${APP_INTERNAL_HOSTNAME:-nmdc-test.mcb180107.projects.jetstream-cloud.org}
+      PROXY_TARGET_HOSTNAME: app
+      PROXY_TARGET_PORT: ${APP_SERVER_PORT:-5000}
     ports:
       - "80:80"
       - "443:443"
-
-    # Run caddy as a reverse proxy.
-    #
-    # References:
-    # - https://caddyserver.com/docs/quick-starts/reverse-proxy
-    # - https://caddyserver.com/docs/command-line#caddy-reverse-proxy
-    #
-    # Note: The `>` character tells YAML to "fold" the newlines in the multiline string into spaces,
-    #       and the `-` after it tells YAML not to append a trailing newline to the resulting string.
-    #       Reference: https://yaml-multiline.info/
-    #
-    # Note: The `${ENV_VAR_NAME:-default_value}` syntax tells Docker to use the value of the specified environment
-    #       variable if that environment variable exists; otherwise, use the value that follows the `:-` delimiter.
-    #
-    command: >-
-      caddy reverse-proxy
-        --access-log
-        --from '${APP_EXTERNAL_HOSTNAME:-edge-dev.microbiomedata.org}:443'
-        --to 'app:${APP_SERVER_PORT:-5000}'
+    volumes:
+      # Put a shell script into the folder the container will check for upon startup.
+      # Reference: https://github.com/nginxinc/docker-nginx/blob/f0fc31f0f73d59cc46e16fae973065a6aea63c15/entrypoint/docker-entrypoint.sh#L16
+      - ./create_ssl_cert.sh:/docker-entrypoint.d/create_ssl_cert.sh
+      # Note: The container will replace the environment variable references within the template, with their values
+      #       defined in the `environment` section above, and store the result at `/etc/nginx/conf.d/default.conf`.
+      - ./nginx-default.conf.template:/etc/nginx/templates/default.conf.template

--- a/docs/initialize_vm_on_jetstream2.sh
+++ b/docs/initialize_vm_on_jetstream2.sh
@@ -125,9 +125,3 @@ echo "1. $ cd ~                        # Go to your home directory"
 echo "2. $ vi .env                     # Create environment variables"
 echo "3. $ docker compose up --detach  # Spin up the Docker Compose stack"
 echo
-echo "Note: If you haven't already updated your DNS server to map your domain "
-echo "      to this VM, you can do that now. After doing that, restart the    "
-echo "      Docker Compose stack so Caddy can register an SSL certificate for "
-echo "      the domain. You can restart the Docker Compose stack by running:  "
-echo "      $ docker compose restart                                          "
-echo

--- a/docs/nginx-default.conf.template
+++ b/docs/nginx-default.conf.template
@@ -1,0 +1,25 @@
+# Proxy HTTPS requests.
+server {
+    listen              443 ssl;
+    server_name         ${SERVER_NAME};
+    ssl_certificate     /root/ssl.crt;
+    ssl_certificate_key /root/ssl.crt.key;
+
+    # Refrain from limiting the request size.
+    # Note: Cloudflare may apply its own limits.
+    client_max_body_size 0;
+
+    location / {
+        proxy_pass       http://${PROXY_TARGET_HOSTNAME}:${PROXY_TARGET_PORT};
+        proxy_set_header Host            $http_host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+
+# Redirect HTTP requests to the corresponding HTTPS URLs.
+server {
+    listen      80;
+    server_name ${SERVER_NAME};
+    return      301 https://$server_name$request_uri;
+}


### PR DESCRIPTION
In this branch, I updated our production deployment configuration to use Nginx instead of Caddy. In addition to updating the "docker compose" file and a "readme" file, it involved defining an "Nginx configuration file" and writing a script that generates a self-signed SSL certificate. The self-signed SSL certificate will be used to encrypt traffic between Cloudflare and the VM. Cloudflare will present a different, _valid_ SSL certificate to end users.

There is room for improvement in this branch (e.g. re-organizing the files so they are not all in a top-level directory named `docs`). Given my availability this week, I want to get this merged in already. I'll file a separate ticket (assigned to myself) about re-organizing the files.