### PR TITLE
Corrected input to MetaG pipeline

### DIFF
--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -174,10 +174,10 @@ workflow main_workflow {
         input:
             memory=metaAssembly_memory,
             threads=metaAssembly_threads,
-            input_file=input_files,
+            input_file=rqcfiltered_reads,
             input_fq1=input_fq1,
             input_fq2=input_fq2,
-            input_interleaved = input_interleaved,
+            input_interleaved = true,
             outdir=metaAssembly_outdir,
             proj=proj,
             bbtools_container=metaAssembly_bbtools_container


### PR DESCRIPTION
@mflynn-lanl found a problem with the MetaG pipeline where MetaAssembly wasn't taking the input files from ReadsQC.

Successful test on dev: https://dev.nmdc-edge.org/user/project?code=IWYLAU7Z1q7BMlWb