### PR TITLE
Remove menu item so app's menu matches website's menu

### DIFF
--- a/webapp/client/src/containers/AboutDropdown.js
+++ b/webapp/client/src/containers/AboutDropdown.js
@@ -18,9 +18,6 @@ const AboutDropdown = (props) => {
           <a title="Advisory" href="https://microbiomedata.org/advisory/">
             Advisory
           </a>
-          <a title="Diversity, Equity, and Inclusion" href="https://microbiomedata.org/idea-action-plan/">
-            Diversity, Equity, and Inclusion
-          </a>
           <a title="Data Use Policy" href="https://microbiomedata.org/nmdc-data-use-policy/">
             Data Use Policy
           </a>


### PR DESCRIPTION
Hi @mflynn-lanl and @yxu-lanl, the NMDC website was updated earlier today such that it doesn't have this item in it anymore. In this PR, I updated NMDC EDGE's menu to match the website's. I don't know how new versions of NMDC EDGE get deployed to production these days. I would like for this change to be in production by next Monday (that's when the Data Portal's menu will be updated in production).