### PR TITLE
added maxRetries

### DIFF
--- a/data/workflow/templates/metaG_options.tmpl
+++ b/data/workflow/templates/metaG_options.tmpl
@@ -1,4 +1,5 @@
 {
     "final_workflow_outputs_dir":<OUTDIR>,
-    "use_relative_output_paths": true
+    "use_relative_output_paths": true,
+    "maxRetries": 3
 }


### PR DESCRIPTION
changed the options.json template to add a default maxRetries to handle automatically re-running tasks that fail because of the error 'Unable to determine alive'