### PR TITLE
Added chastity filter to metaG 

### DIFF
--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -123,7 +123,8 @@ workflow main_workflow {
                 input_fq2=[],
                 proj=proj,
                 interleaved=true,
-                shortRead=short_read
+                shortRead=short_read,
+                chastityfilter_flag=readsqc_preprocess.isIllumina
         }
     }
 

--- a/data/workflow/templates/readsQC_wdl.tmpl
+++ b/data/workflow/templates/readsQC_wdl.tmpl
@@ -33,7 +33,8 @@ workflow main_workflow {
                 input_fq2=[],
                 proj=<WORKFLOW>_prefix,
                 interleaved=true,
-                shortRead=<WORKFLOW>_short_read
+                shortRead=<WORKFLOW>_short_read,
+                chastityfilter_flag=readsqc_preprocess.isIllumina
         }
     }
 

--- a/webapp/server/config/workflow.js
+++ b/webapp/server/config/workflow.js
@@ -13,7 +13,7 @@ workflowlist = {
     },
     ReadsQC: {
         project_conf_tmpl: 'readsQC.tmpl',
-        wdl: 'https://raw.githubusercontent.com/microbiomedata/ReadsQC/refs/heads/nmdc_edge_chastity_filter/rqcfilter.wdl',
+        wdl: 'https://raw.githubusercontent.com/microbiomedata/ReadsQC/refs/tags/v1.0.14-alpha.1/rqcfilter.wdl',
         wdl_imports: 'metaG/imports.zip',
         name: 'jgi_rqcfilter',
         full_name: 'ReadsQC',

--- a/webapp/server/config/workflow.js
+++ b/webapp/server/config/workflow.js
@@ -13,7 +13,7 @@ workflowlist = {
     },
     ReadsQC: {
         project_conf_tmpl: 'readsQC.tmpl',
-        wdl: 'https://raw.githubusercontent.com/microbiomedata/ReadsQC/refs/tags/v1.0.14/rqcfilter.wdl',
+        wdl: 'https://raw.githubusercontent.com/microbiomedata/ReadsQC/refs/heads/nmdc_edge_chastity_filter/rqcfilter.wdl',
         wdl_imports: 'metaG/imports.zip',
         name: 'jgi_rqcfilter',
         full_name: 'ReadsQC',


### PR DESCRIPTION
ShortReadsQC was updated to have a [chastity filter](https://github.com/microbiomedata/ReadsQC/blob/abe6bcb3f7f18502cc48f7389273b093016b4045/rqcfilter.wdl#L25 ) so that SRA inputs are handled correctly.

Successful Tests on Dev:
ReadsQC: [DckwLWfmThoiBGnT](https://nmdc-edge.org/user/project?code=DckwLWfmThoiBGnT)
MetaG Pipeline: [T7fJEOhhZnbBMKzA](https://nmdc-edge.org/user/project?code=T7fJEOhhZnbBMKzA)