### PR TITLE
Add full pipeline folder to be available individual inputs

### DIFF
--- a/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAnnotation.js
+++ b/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAnnotation.js
@@ -85,7 +85,7 @@ export function MetaAnnotation(props) {
                                 validFile={form.input_fasta_validInput}
                                 dataSources={['project', 'upload', 'public', 'globus']}
                                 fileTypes={['fasta', 'fa', 'fna', 'fasta.gz', 'fa.gz', 'fna.gz']}
-                                projectTypes={['Metagenome Assembly']} viewFile={false} />
+                                projectTypes={['Metagenome Pipeline','Metagenome Assembly']} viewFile={false} />
 
                             <input type="hidden" name="fasta_hidden" id="fasta_hidden"
                                 value={form['input_fasta']}

--- a/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAssembly.js
+++ b/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAssembly.js
@@ -20,8 +20,8 @@ export function MetaAssembly(props) {
             <Header toggle={true} toggleParms={toggleParms} title={'Input'} collapseParms={collapseParms} />
             <Collapse isOpen={!collapseParms} id={"collapseParameters-" + props.name} >
                 <CardBody>
-                    <MyTooltip id='MetaAssembly' text="Input Raw Reads" tooltip={workflowInputTips['MetaAssembly']['fastq_tip']} showTooltip={true} place="right" />
-                    <FastqInput projectTypes={['ReadsQC','Retrieve SRA Data']} name={props.name} full_name={props.full_name} 
+                    <MyTooltip id='MetaAssembly' text="Input Filtered Reads" tooltip={workflowInputTips['MetaAssembly']['fastq_tip']} showTooltip={true} place="right" />
+                    <FastqInput projectTypes={['Metagenome Pipeline','ReadsQC','Retrieve SRA Data']} name={props.name} full_name={props.full_name} 
                     setParams={props.setParams} collapseParms={true} platformOptions={true} />
                 </CardBody>
             </Collapse>

--- a/webapp/client/src/pipelines/MetaG/Workflow/Forms/ReadbasedAnalysis.js
+++ b/webapp/client/src/pipelines/MetaG/Workflow/Forms/ReadbasedAnalysis.js
@@ -113,8 +113,8 @@ export function ReadbasedAnalysis(props) {
                         </Col>
                     </Row>
                     <br></br> */}
-                    <MyTooltip id='ReadbasedAnalysis' text="Input Raw Reads" tooltip={workflowInputTips['ReadbasedAnalysis']['fastq_tip']} showTooltip={true} place="right" />
-                    <FastqInput projectTypes={['ReadsQC', 'Retrieve SRA Data']} singleType={'single-end or interleaved'} name={props.name} full_name={props.full_name}
+                    <MyTooltip id='ReadbasedAnalysis' text="Input Filtered Reads" tooltip={workflowInputTips['ReadbasedAnalysis']['fastq_tip']} showTooltip={true} place="right" />
+                    <FastqInput projectTypes={['Metagenome Pipeline','ReadsQC', 'Retrieve SRA Data']} singleType={'single-end or interleaved'} name={props.name} full_name={props.full_name}
                         setParams={updateFastqInputs} collapseParms={true} paired-input-max={form['paired-input-max']} platformOptions={true} />
                 </CardBody>
             </Collapse>


### PR DESCRIPTION
Changes in [file selection folder](https://github.com/microbiomedata/nmdc-edge/blob/main/webapp/client/src/pipelines/MetaG/Workflow/Forms/) to add MetaG pipeline results as an input option for annotation, assembly, and read-based analysis. Also specified that filtered reads should be input to assembly and rba. 