### PR TITLE
383 remove outputs irrelevant to users

### DIFF
--- a/data/workflow/WDL/metaG/mbin_nmdc_output.wdl
+++ b/data/workflow/WDL/metaG/mbin_nmdc_output.wdl
@@ -186,7 +186,7 @@ task make_output{
     command <<<
         set -euo pipefail
         mkdir -p ~{outdir}
-        cp ~{activity_json} ~{object_json} ~{outdir}
+        # cp ~{activity_json} ~{object_json} ~{outdir}
         cp ~{low}  ~{outdir}/~{proj}_bins.lowDepth.fa
         cp ~{short} ~{outdir}/~{proj}_bins.tooShort.fa
         cp ~{unbinned} ~{outdir}/~{proj}_bins.unbinned.fa

--- a/data/workflow/templates/metagenome_pipeline_wdl.tmpl
+++ b/data/workflow/templates/metagenome_pipeline_wdl.tmpl
@@ -448,7 +448,8 @@ task finish {
                 ~{scaffold} 'Assembled scaffold fasta' \
                 ~{agp} 'Assembled AGP file' \
                 ~{bam} 'Metagenome Alignment BAM file'
-            cp ~{fasta} ~{scaffold} ~{agp} ~{bam} ~{covstats} ~{asmstats} activity.json data_objects.json ~{assemdir}/
+            cp ~{fasta} ~{scaffold} ~{agp} ~{bam} ~{covstats} ~{asmstats} ~{assemdir}/
+            # cp ~{fasta} ~{scaffold} ~{agp} ~{bam} ~{covstats} ~{asmstats} activity.json data_objects.json ~{assemdir}/
 
             # Generate annotation objects
             nmdc gff2json ~{functional_gff} -of features.json -oa annotations.json -ai ~{informed_by}
@@ -484,9 +485,11 @@ task finish {
             #	~{smart_gff} ~{supfam_gff} ~{cath_funfam_gff} ~{ko_ec_gff} \
             #	~{stats_tsv} ~{stats_json} \
             #	~{annodir}/
-            cp features.json annotations.json activity.json data_objects.json ~{annodir}/
+            cp features.json annotations.json ~{annodir}/
+            # cp features.json annotations.json activity.json data_objects.json ~{annodir}/
 
-            cp activity.json data_objects.json ~{final_hqmq_bins_zip} \
+            # cp activity.json data_objects.json ~{final_hqmq_bins_zip} \
+            cp ~{final_hqmq_bins_zip} \
             ~{final_lq_bins_zip} ~{final_gtdbtk_bac_summary} ~{final_gtdbtk_ar_summary} ~{short} ~{low} \
             ~{final_unbinned_fa} ~{final_checkm} ~{mags_version} ~{final_stats_json} ~{barplot} ~{heatmap} \
             ~{kronaplot} ~{magsdir}/

--- a/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAnnotation.js
+++ b/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAnnotation.js
@@ -85,7 +85,7 @@ export function MetaAnnotation(props) {
                                 validFile={form.input_fasta_validInput}
                                 dataSources={['project', 'upload', 'public', 'globus']}
                                 fileTypes={['fasta', 'fa', 'fna', 'fasta.gz', 'fa.gz', 'fna.gz']}
-                                projectTypes={['Metagenome Assembly']} viewFile={false} />
+                                projectTypes={['Metagenome Pipeline','Metagenome Assembly']} viewFile={false} />
 
                             <input type="hidden" name="fasta_hidden" id="fasta_hidden"
                                 value={form['input_fasta']}

--- a/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAssembly.js
+++ b/webapp/client/src/pipelines/MetaG/Workflow/Forms/MetaAssembly.js
@@ -20,8 +20,8 @@ export function MetaAssembly(props) {
             <Header toggle={true} toggleParms={toggleParms} title={'Input'} collapseParms={collapseParms} />
             <Collapse isOpen={!collapseParms} id={"collapseParameters-" + props.name} >
                 <CardBody>
-                    <MyTooltip id='MetaAssembly' text="Input Raw Reads" tooltip={workflowInputTips['MetaAssembly']['fastq_tip']} showTooltip={true} place="right" />
-                    <FastqInput projectTypes={['ReadsQC','Retrieve SRA Data']} name={props.name} full_name={props.full_name} 
+                    <MyTooltip id='MetaAssembly' text="Input Filtered Reads" tooltip={workflowInputTips['MetaAssembly']['fastq_tip']} showTooltip={true} place="right" />
+                    <FastqInput projectTypes={['Metagenome Pipeline','ReadsQC','Retrieve SRA Data']} name={props.name} full_name={props.full_name} 
                     setParams={props.setParams} collapseParms={true} platformOptions={true} />
                 </CardBody>
             </Collapse>

--- a/webapp/client/src/pipelines/MetaG/Workflow/Forms/ReadbasedAnalysis.js
+++ b/webapp/client/src/pipelines/MetaG/Workflow/Forms/ReadbasedAnalysis.js
@@ -113,8 +113,8 @@ export function ReadbasedAnalysis(props) {
                         </Col>
                     </Row>
                     <br></br> */}
-                    <MyTooltip id='ReadbasedAnalysis' text="Input Raw Reads" tooltip={workflowInputTips['ReadbasedAnalysis']['fastq_tip']} showTooltip={true} place="right" />
-                    <FastqInput projectTypes={['ReadsQC', 'Retrieve SRA Data']} singleType={'single-end or interleaved'} name={props.name} full_name={props.full_name}
+                    <MyTooltip id='ReadbasedAnalysis' text="Input Filtered Reads" tooltip={workflowInputTips['ReadbasedAnalysis']['fastq_tip']} showTooltip={true} place="right" />
+                    <FastqInput projectTypes={['Metagenome Pipeline','ReadsQC', 'Retrieve SRA Data']} singleType={'single-end or interleaved'} name={props.name} full_name={props.full_name}
                         setParams={updateFastqInputs} collapseParms={true} paired-input-max={form['paired-input-max']} platformOptions={true} />
                 </CardBody>
             </Collapse>


### PR DESCRIPTION
This overlaps with https://github.com/microbiomedata/nmdc-edge/pull/382 because I forgot to change back to main before branching. 

Changes specific to this PR / ticket:
- commenting out instances of `activity.json` and `data_objects.json` because I don't think the users should be able to see these files. They seem to be legacy lines because these things (activity, data_objects, etc) are now managed by nmdc automation. They're also not present in rqc, genomad, and rba outputs. 

Draft because I'm not fully familiar with all the JS and need to check if I broke anything. 