### PR TITLE
Updated ReadsQC preprocessing

### DIFF
--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -16,7 +16,7 @@ workflow readsqc_preprocess {
         call gzip_input_int as gzip_int {
         input:
             input_files=input_files,
-            container=container,
+            container=bbtools_container,
             outdir=outdir
         }
     }
@@ -33,7 +33,7 @@ workflow readsqc_preprocess {
         call gzip_input_int as gzip_pe {
         input:
             input_files=interleave_reads.out_fastq,
-            container=container,
+            container=bbtools_container,
             outdir=outdir
         }
 

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -35,7 +35,8 @@ workflow readsqc_preprocess {
         input:
             input_files=interleave_reads.out_fastq,
             container=bbtools_container,
-            outdir=outdir
+            outdir=outdir,
+            shortRead=true
         }
 
     }

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -155,7 +155,6 @@ task interleave_reads{
 
         # Validate that the read1 and read2 files are sorted correctly
         reformat.sh -Xmx~{memory}G verifypaired=t in=~{output_file}
-        echo ~{output_file}
     >>>
 
     runtime {
@@ -165,6 +164,6 @@ task interleave_reads{
     }
 
     output {
-            File out_fastq = read_string(stdout())
+            File out_fastq = "~{output_file}"
     }
 }

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -6,6 +6,7 @@ workflow readsqc_preprocess {
         Array[File] input_fq1
         Array[File] input_fq2
         String  container="bfoster1/img-omics:0.1.9"
+        String  bbtools_container="microbiomedata/bbtools:38.96"
         String  outdir
         Boolean input_interleaved
         Boolean shortRead
@@ -26,7 +27,7 @@ workflow readsqc_preprocess {
             input:
                 input_files = [file.left,file.right],
                 output_file = basename(file.left) + "_" + basename(file.right),
-                container = container
+                container = bbtools_container
         }
         }
         call gzip_input_int as gzip_pe {
@@ -54,24 +55,40 @@ task gzip_input_int {
 
     command <<<
         set -euo pipefail
+        
         mkdir -p ~{outdir}
-        if file --mime -b ~{input_files[0]} | grep gzip > /dev/null ; then
-            cp ~{sep=" " input_files} ~{outdir}/
-            header=`zcat ~{input_files[0]} | (head -n1; dd status=none of=/dev/null)`
-        else
-            cp ~{sep=" " input_files} ~{outdir}/
-            gzip -f ~{outdir}/*.fastq
-            header=`cat ~{input_files[0]} | (head -n1; dd status=none of=/dev/null)`
-        fi
-        # prefix array
-        for i in ~{outdir}/*.gz
+        cp ~{sep=" " input_files} ~{outdir}/
+
+        needs_merge=false
+        for f in ~{outdir}/*; 
         do
-            name=~{dollar}(basename "$i")
-            prefix=~{dollar}{name%%.*}
-            echo $prefix >> fileprefix.txt
-        done    
-        # simple format check 
-        NumField=`echo $header | cut -d' ' -f2 | awk -F':' "{print NF}"`
+            base=$(basename "$f")
+            if [[ ! "$base" =~ \.fastq$ && ! "$base" =~ \.gz$ ]]; then
+                needs_merge=true
+            fi
+        done
+
+        if $needs_merge; then
+            cat ~{outdir}/* > ~{outdir}/merged.fastq.gz
+            header=$(zcat ~{outdir}/merged.fastq.gz | (head -n1; dd status=none of=/dev/null))
+            echo "merged.fastq" > fileprefix.txt
+        else
+            if file --mime -b ~{input_files[0]} | grep gzip > /dev/null ; then
+                header=$(zcat ~{input_files[0]} | (head -n1; dd status=none of=/dev/null))
+            else
+                gzip -f ~{outdir}/*.fastq
+                header=$(cat ~{input_files[0]} | (head -n1; dd status=none of=/dev/null))
+            fi
+            # prefix array
+            for i in ~{outdir}/*.gz ~{outdir}/*.fastq;
+            do
+                name=~{dollar}(basename "$i")
+                prefix=~{dollar}{name%%.*}
+                echo $prefix >> fileprefix.txt
+            done
+        fi
+
+        NumField=$(echo $header | cut -d' ' -f2 | awk -F':' '{print NF}')
         if [ $NumField -eq 4 ]; then echo "true"; else echo "false"; fi
     >>>
 
@@ -88,28 +105,21 @@ task gzip_input_int {
 	}
 }
 
-
 task interleave_reads{
     input {
         Array[File] input_files
         String output_file = "interleaved.fastq.gz"
         String container
+        Int memory = 10
     }
 
     command <<<
         set -euo pipefail
-        if file --mime -b ~{input_files[0]} | grep gzip > /dev/null ; then
-            paste <(gunzip -c ~{input_files[0]} | paste - - - -) <(gunzip -c ~{input_files[1]} | paste - - - -) | tr '\t' '\n' | gzip -c > ~{output_file}
-            echo ~{output_file}
-        else
-            if [[ "~{output_file}" == *.gz ]]; then
-                paste <(cat ~{input_files[0]} | paste - - - -) <(cat ~{input_files[1]} | paste - - - -) | tr '\t' '\n' | gzip -c > ~{output_file}
-                echo ~{output_file}
-            else
-                paste <(cat ~{input_files[0]} | paste - - - -) <(cat ~{input_files[1]} | paste - - - -) | tr '\t' '\n' | gzip -c > ~{output_file}.gz
-                echo ~{output_file}.gz
-            fi
-        fi
+        reformat.sh in=~{input_files[0]} in2=~{input_files[1]} out=~{output_file}
+
+        # Validate that the read1 and read2 files are sorted correctly
+        reformat.sh -Xmx~{memory}G verifypaired=t in=~{output_file}
+        echo ~{output_file}
     >>>
 
     runtime {

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -76,7 +76,7 @@ task gzip_input_int {
             cat ~{outdir}/* > ~{outdir}/merged.fastq.gz
             # Validate gzipped file for shortreads
             if [ "~{shortRead}" = "true" ]; then
-                reformat.sh -Xmx~{memory}G verifypaired=t in=~{outdir}/merged.fastq.gz
+                reformat.sh -Xmx~{memory}G verifypaired=t in=~{outdir}/merged.fastq.gz out=/dev/null
             fi
             
             header=$(zcat ~{outdir}/merged.fastq.gz | (head -n1; dd status=none of=/dev/null))
@@ -90,7 +90,7 @@ task gzip_input_int {
             # Validate gzipped file
             for file in ~{outdir}/*.gz; do
                 if [ "~{shortRead}" = "true" ]; then
-                    reformat.sh -Xmx~{memory}G verifypaired=t in="$file"
+                    reformat.sh -Xmx~{memory}G verifypaired=t in="$file" out=/dev/null
                 fi
             done
 

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -73,7 +73,13 @@ task gzip_input_int {
         done
 
         if $needs_merge; then
-            cat ~{outdir}/* > ~{outdir}/merged.fastq.gz
+            if file --mime -b ~{input_files[0]} | grep -q gzip; then
+                cat ~{outdir}/* > ~{outdir}/merged.fastq.gz
+            else
+                cat ~{outdir}/* > ~{outdir}/merged.fastq 
+                gzip ~{outdir}/merged.fastq
+            fi
+
             # Validate gzipped file for shortreads
             if [ "~{shortRead}" = "true" ]; then
                 reformat.sh -Xmx~{memory}G verifypaired=t in=~{outdir}/merged.fastq.gz out=/dev/null
@@ -132,8 +138,6 @@ task interleave_reads{
     input {
         Array[File] input_files
         String output_file = "interleaved.fastq.gz"
-        String target_reads_1="raw_reads_1.fastq.gz"
-        String target_reads_2="raw_reads_2.fastq.gz"
         String container
         Int memory = 10
     }

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -78,13 +78,13 @@ task gzip_input_int {
             echo "merged.fastq" > fileprefix.txt
         else
             # gzip fastqs
-            gzip -f ~{outdir}/*.fastq
+            if ls ~{outdir}/*.fastq 1> /dev/null 2>&1; then
+                gzip -f ~{outdir}/*.fastq
+            fi
+
             # Validate gzipped file
             for file in ~{outdir}/*.gz; do
-                reformat.sh \
-                    -Xmx~{memory}G \
-                    verifypaired=t \
-                    in="$file"
+                reformat.sh -Xmx~{memory}G verifypaired=t in="$file"
             done
 
             if file --mime -b ~{input_files[0]} | grep -q gzip; then

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -146,8 +146,10 @@ task interleave_reads{
             # Check if filename ends with .gz
             if [[ ~{input_files[0]}  != *.gz ]]; then
                 mv ~{input_files[0]} ~{input_files[0]}.gz
+            fi
             if [[ ~{input_files[1]}  != *.gz ]]; then
                 mv ~{input_files[1]} ~{input_files[1]}.gz
+            fi
             reformat.sh in=~{input_files[0]}.gz in2=~{input_files[1]}.gz out=~{output_file}
         else
             reformat.sh in=~{input_files[0]} in2=~{input_files[1]} out=~{output_file}

--- a/data/workflow/WDL/metaG/readsqc_preprocess.wdl
+++ b/data/workflow/WDL/metaG/readsqc_preprocess.wdl
@@ -72,7 +72,7 @@ task gzip_input_int {
         if $needs_merge; then
             cat ~{outdir}/* > ~{outdir}/merged.fastq.gz
             # Validate gzipped file
-            reformat.sh -Xmx~{memory}G verifypaired=t in=~{outdir}/merged.fastq.gz of=/dev/null
+            reformat.sh -Xmx~{memory}G verifypaired=t in=~{outdir}/merged.fastq.gz
             
             header=$(zcat ~{outdir}/merged.fastq.gz | (head -n1; dd status=none of=/dev/null))
             echo "merged.fastq" > fileprefix.txt
@@ -84,8 +84,7 @@ task gzip_input_int {
                 reformat.sh \
                     -Xmx~{memory}G \
                     verifypaired=t \
-                    in="$file" \
-                    of=/dev/null
+                    in="$file"
             done
 
             if file --mime -b ~{input_files[0]} | grep -q gzip; then


### PR DESCRIPTION
Updated rqc preprocessing to handle URLs and to check if reads are interleaved correctly.
https://github.com/microbiomedata/nmdc-edge/blob/17ae13f7ff8083b759516cbab3bc063c718e9eb4/data/workflow/WDL/metaG/readsqc_preprocess.wdl#L66

https://github.com/microbiomedata/nmdc-edge/blob/17ae13f7ff8083b759516cbab3bc063c718e9eb4/data/workflow/WDL/metaG/readsqc_preprocess.wdl#L159

Tests on Dev:
Bulk Submission (metag pipeline): [ioWfdPdBeqNABdIY](https://dev.nmdc-edge.org/user/bulksubmission?code=ioWfdPdBeqNABdIY)
QC Short Reads URL: [iQeTlO8gsxtEnJLD ](https://dev.nmdc-edge.org/user/project?code=iQeTlO8gsxtEnJLD)
QC Short Reads:[xRrU1W4v0TNklyJm](https://dev.nmdc-edge.org/user/project?code=xRrU1W4v0TNklyJm)
QC Non-Int URL: [IhdP4vMJGt527mA5](https://dev.nmdc-edge.org/user/project?code=IhdP4vMJGt527mA5)
QC Non-Int: [z5adiZVmuTEkF870](https://dev.nmdc-edge.org/user/project?code=z5adiZVmuTEkF870)
QC Long Reads: [Qircq8PzyuGoVMCG](https://dev.nmdc-edge.org/user/project?code=Qircq8PzyuGoVMCG)
