### PR TITLE
Update viral-plasmid_tasks.wdl

### DIFF
--- a/data/workflow/WDL/metaG/viral-plasmid_tasks.wdl
+++ b/data/workflow/WDL/metaG/viral-plasmid_tasks.wdl
@@ -19,7 +19,7 @@ task geNomad_full {
         Int? CPU = 4
         Boolean? calibration = false
         Float? fdr = 0.1
-        String prefix=sub(sub(sub(sub(sub(sub(basename(ASM_FASTA), "\\.fna", ""), "\\.fasta", ""), "\\.fa", ""), "\\.fna\\.gz", ""), "\\.fasta\\.gz", ""), "\\.fa\\.gz", "")
+        String prefix=sub(sub(sub(sub(sub(sub(basename(ASM_FASTA), "\\.fna\\.gz", ""), "\\.fasta\\.gz", ""), "\\.fa\\.gz", ""), "\\.fna", ""), "\\.fasta", ""), "\\.fa", "")
     }
 
     command <<<


### PR DESCRIPTION
Updating the order for literal matching. This way, sample.fasta.gz becomes "sample" rather than "sample.gz", which could potentially be the case with current ordering.