### PR TITLE
added ~{} around OUTDIR

### DIFF
--- a/data/workflow/WDL/metaG/viral-plasmid_tasks.wdl
+++ b/data/workflow/WDL/metaG/viral-plasmid_tasks.wdl
@@ -35,7 +35,7 @@ task geNomad_full {
         fi
         if [ ~{OPTION["relaxed"]} == true ]; then
             genomad end-to-end --relaxed --splits 4 ~{proj_name} ~{OUTDIR} ~{GENOMAD_DB} \
-            && mv OUTDIR/~{proj_name}_summary ~{GeNomad_Summary}
+            && mv ~{OUTDIR}/~{proj_name}_summary ~{GeNomad_Summary}
 
         fi
         if [ ~{OPTION["conservative"]} == true ]; then


### PR DESCRIPTION
I fixed a bug in viral-plasmids_tasks.wdl. OUTDIR was not properly referenced in the command section